### PR TITLE
Fix legend colour and text vertical alignment

### DIFF
--- a/src/ui/const.js
+++ b/src/ui/const.js
@@ -20,6 +20,7 @@ export const classes = {
   GRAPH_LEGEND_CONTENT: "legend-content",
   GRAPH_LEGEND_ITEM: "legend-item",
   GRAPH_LEGEND_COLOR: "legend-item-color",
+  GRAPH_LEGEND_ITEM_TEXT: "legend-item-text",
   DATA_TABLE_CELL: "data-table-cell",
   DATA_TABLE_HEADER: "data-table-header",
   DATA_TABLE_HEADER_ARROWS: "data-table-header-arrows",

--- a/src/ui/graph/colorLegend.js
+++ b/src/ui/graph/colorLegend.js
@@ -28,6 +28,7 @@ export function displayColorLegendSection(data, title) {
 
     colorEl.style.backgroundColor = mapping.color;
     labelEl.innerHTML = mapping.label;
+    labelEl.classList.add(classes.GRAPH_LEGEND_ITEM_TEXT);
 
     itemEl.append(colorEl);
     itemEl.append(labelEl);

--- a/styles.css
+++ b/styles.css
@@ -419,10 +419,18 @@ Graph
             display: flex;
             flex-direction: row;
             gap: 0.3rem;
+            position: relative;
           }
           .legend-item-color {
+            position: absolute;
             width: 1rem;
             height: 1rem;
+            top: 50%;
+            -ms-transform: translateY(-50%);
+            transform: translateY(-50%);
+          }
+          .legend-item-text {
+            margin-left: 1.5rem;
           }
         }
       }


### PR DESCRIPTION
- For some reason, the spacing issue with the legend is now fixed after the frontend improvement here: https://github.com/BFSSI-Bioinformatics-Lab/tds-dietary-exposure-tool/pull/1. But there is still a problem where the text and the colour of the legend are slightly vertically misaligned. So we fix this alignment instead.