### PR TITLE
Change age-sex group to age group for grouped bar chart

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -725,7 +725,7 @@ const LangEN = {
 
   filters: {
     graphSelects: {
-      [GraphTypes.RBASG]: "Results by Age-Sex Group",
+      [GraphTypes.RBASG]: "Results by Age Group",
       [GraphTypes.RBF]: "Results by Food",
       [GraphTypes.RBFG]: "Results by Food Group",
     },
@@ -763,7 +763,7 @@ const LangEN = {
       [ConsumptionUnits.KGBW]: "ng/kg bw per day",
     },
     rbasgDomainFormat: {
-      [RbasgDomainFormat.AGESEX]: "Age-Sex Group",
+      [RbasgDomainFormat.AGESEX]: "Age Group",
       [RbasgDomainFormat.YEAR]: "Year",
     },
     rbfgRangeFormat: {
@@ -826,6 +826,8 @@ const LangEN = {
       filename: "Graph Export",
     },
     [GraphTypes.RBASG]: {
+      titleByAgeGroups: "Dietary exposure estimate by age, {{ chemical }} Years: {{ selectedYears }}",
+      titleByYears: "Dietary exposure estimate, age {{ ageGroups }}, {{ chemical }}",
       title: "Dietary Exposure Estimate by Age-Sex Group",
       range: "Dietary Exposure",
       domain: {
@@ -1416,7 +1418,7 @@ const LangFR = {
       [ConsumptionUnits.KGBW]: "ng/kg pc par jour",
     },
     rbasgDomainFormat: {
-      [RbasgDomainFormat.AGESEX]: "Groupe âge-sexe",
+      [RbasgDomainFormat.AGESEX]: "Groupe d'âge",
       [RbasgDomainFormat.YEAR]: "Année",
     },
     rbfgRangeFormat: {
@@ -1475,8 +1477,9 @@ const LangFR = {
       filename: "Exportation du graphique",
     },
     [GraphTypes.RBASG]: {
-      title:
-        "Estimation de l'exposition alimentaire par groupe d'âge et de sexe",
+      titleByAgeGroups: "Estimation de l'exposition alimentaire par âge, {{ chemical }} Années: {{ selectedYears }}",
+      titleByYears: "Estimation de l'exposition alimentaire âge {{ ageGroups }}, {{ chemical }}",
+      title: "Estimation de l'exposition alimentaire par groupe d'âge et de sexe",
       range: "Exposition alimentaire",
       domain: {
         [RbasgDomainFormat.AGESEX]: "Groupe d'âge",

--- a/src/ui/graphComponent.js
+++ b/src/ui/graphComponent.js
@@ -1,4 +1,4 @@
-import { GraphLegendTypes, GraphTypes, sexGroups, getTranslations } from "../const.js";
+import { GraphLegendTypes, GraphTypes, sexGroups, getTranslations, Translation } from "../const.js";
 import { classes, el } from "./const.js";
 import {
   formatRbasgToGroupedBar,
@@ -86,11 +86,11 @@ export function displayGraph(data) {
     },
   };
 
+  console.log("FILTERS: ", filters);
+
   const graphMapping = {
     [GraphTypes.RBASG]: {
-      graphTitle: `${getTranslations().graphs[GraphTypes.RBASG].title}, ${
-        filters.chemical
-      }`,
+      graphTitle: filters.showByAgeSexGroup? Translation.translate(`graphs.${GraphTypes.RBASG}.titleByAgeGroups`, {chemical: filters.chemical, selectedYears: filters.years.join(", ")}) : Translation.translate(`graphs.${GraphTypes.RBASG}.titleByYears`, {chemical: filters.chemical, ageGroups: filters.ageSexGroups.join(", ")}),
       colorLegendMappings: [colorLegendMapping.sexGroup],
       getDataFn: getRbasg,
       getGraphDataFn: formatRbasgToGroupedBar,


### PR DESCRIPTION
- Show the years/age groups in the title of the graph depending on whether the user is viewing by age or years
- Change all instance of `Age-sex group` in the first plot with `Age group`

<br>

> [!NOTE]
>   We did not change the `age-sex group` in the table of the first graph since the column for that table still has a sex indicator