### PR TITLE
Revert graph select from being evenly spread

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
 
       <h4 id="graph-select-title" class="bold mt-4"></h4>
 
-      <div id="graph-selects-container" class="mb-4 d-flex justify-content-around">
+      <div id="graph-selects-container" class="mb-4 d-flex">
         <div id="rbasg-graph-select" class="graph-select active" value="RBASG">
           <img
             id="rbasg-img"


### PR DESCRIPTION
- Revert back to the original style where the graph selects were all justified to the left