### PR TITLE
Split both sex option for ages 1-8 and 9+

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -197,11 +197,36 @@ export const ageGroups = {
   "71+": "71+",
 };
 
+export const ageGroupOrder = {
+  [ageGroups["1-3"]]: 0,
+  [ageGroups["4-8"]]: 1,
+  [ageGroups["9-13"]]: 2,
+  [ageGroups["14-18"]]: 3,
+  [ageGroups["19-30"]]: 4,
+  [ageGroups["31-50"]]: 5,
+  [ageGroups["51-70"]]: 6,
+  [ageGroups["1-18"]]: 7,
+  [ageGroups["1+"]]: 8,
+  [ageGroups["19+"]]: 9,
+  [ageGroups["71+"]]: 10,
+}
+
+export const ageGroups1To8 = new Set([
+  ageGroups["1-3"],
+  ageGroups["4-8"]
+]); 
+
 export const sexGroups = {
   B: "B",
   F: "F",
   M: "M",
 };
+
+export const sexGroupOrder = {
+  [sexGroups.B]: 0,
+  [sexGroups.F]: 1,
+  [sexGroups.M]: 2
+}
 
 export const suppressedAgeSexGroups = [
   getAgeSex(ageGroups["1-3"], sexGroups.F),
@@ -212,10 +237,9 @@ export const suppressedAgeSexGroups = [
 
 export const ageSexGroups = Object.keys(ageGroups).reduce((result, ageKey) => {
   Object.keys(sexGroups).forEach((sexKey) => {
-    const ageSexGroup = getAgeSex(ageKey, sexKey);
-    if (!suppressedAgeSexGroups.includes(ageSexGroup)) {
-      result[ageSexGroup] = ageSexGroup;
-    }
+    let ageSexGroup = getAgeSex(ageKey, sexKey);
+    if (suppressedAgeSexGroups.includes(ageSexGroup)) return;
+    result[ageSexGroup] = ageSexGroup;
   });
   return result;
 }, {});
@@ -891,6 +915,8 @@ const LangEN = {
       [sexGroups.F]: "F",
       [sexGroups.M]: "M",
       [sexGroups.B]: "M/F",
+      "Both1To8": "M/F (1-8 yrs)",
+      "Both9Plus": "M/F (9+ yrs)"
     },
     noDataMsg: "No results above LOD",
     na: "NA",
@@ -1548,6 +1574,8 @@ const LangFR = {
       [sexGroups.F]: "F",
       [sexGroups.M]: "H",
       [sexGroups.B]: "H/F",
+      "Both1To8": "H/F (1-8 ans)",
+      "Both9Plus": "H/F (9+ ans)"
     },
     noDataMsg: "Aucun résultat supérieur à LD",
     na: "NA",

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -5,7 +5,9 @@ import {
   ageGroups,
   browserLanguage,
   sexGroups,
-  getTranslations
+  getTranslations,
+  ageGroups1To8,
+  Translation
 } from "../const.js";
 
 
@@ -54,6 +56,25 @@ export class NumberTool {
   // hasNonNegative(): Checks if there exists a non-negative number in the arguments
   static hasNonNegative() {
       return this.hasCond(this.isNonNegativeNumber);
+  }
+}
+
+
+// DictTool: Tools for handling dictionaries
+export class DictTool {
+
+  // getMapSorted(dict, compareFn): Retrieves a corresponding map
+  //  to the sorted dictionarys
+  static getMapSorted(dict, compareFn) {
+    const keys = Object.keys(dict);
+    keys.sort((item1, item2) => compareFn(item1, item2, dict));
+
+    const result = new Map();
+    for (const key of keys) {
+      result.set(key, dict[key]);
+    }
+
+    return result;
   }
 }
 
@@ -112,7 +133,14 @@ export function getAgeSex(age, sex) {
  * Return domain specific age group and sex group from domain-specific age-sex group (the opposite of the function getAgeSex)
  */
 export function getAgeAndSex(ageSexGroup) {
-  return ageSexGroup.split(" ");
+  return ageSexGroup.split(" ", 2);
+}
+
+// getSexDisplay: Retrieves the display for a particular sex
+export function getSexDisplay(sex, age) {
+  if (sex != sexGroups.B) return Translation.translate(`misc.sexGroups.${sex}`);
+  if (ageGroups1To8.has(age)) return Translation.translate(`misc.sexGroups.Both1To8`);
+  return Translation.translate(`misc.sexGroups.Both9Plus`);
 }
 
 /**


### PR DESCRIPTION
- The user can now select both sexes for ages either 1-8 or 9+ separately
- Also added a temporary ordering for the age groups