### PR TITLE
Show multiple M/F options for age groups that overlap ages 1-8 and 9+

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -216,11 +216,38 @@ export const ageGroups1To8 = new Set([
   ageGroups["4-8"]
 ]); 
 
+
+export const ageSuperGroups = {
+  Age1To8: "Age1To8",
+  Age9Plus: "Age9Plus"
+}
+
+export const ageSuperGroupsByAgeGroup = {
+  [ageGroups["1-3"]]: new Set([ageSuperGroups.Age1To8]),
+  [ageGroups["4-8"]]: new Set([ageSuperGroups.Age1To8]),
+  [ageGroups["9-13"]]: new Set([ageSuperGroups.Age9Plus]),
+  [ageGroups["14-18"]]: new Set([ageSuperGroups.Age9Plus]),
+  [ageGroups["19-30"]]: new Set([ageSuperGroups.Age9Plus]),
+  [ageGroups["31-50"]]: new Set([ageSuperGroups.Age9Plus]),
+  [ageGroups["51-70"]]: new Set([ageSuperGroups.Age9Plus]),
+  [ageGroups["1-18"]]: new Set([ageSuperGroups.Age1To8, ageSuperGroups.Age9Plus]),
+  [ageGroups["1+"]]: new Set([ageSuperGroups.Age1To8, ageSuperGroups.Age9Plus]),
+  [ageGroups["19+"]]: new Set([ageSuperGroups.Age9Plus]),
+  [ageGroups["71+"]]: new Set([ageSuperGroups.Age9Plus]),
+}
+
 export const sexGroups = {
   B: "B",
   F: "F",
   M: "M",
 };
+
+export const sexSubGroups = {
+  Both1To8: "B1To8",
+  Both9Plus: "B9Plus",
+  Female: "F",
+  Male: "M"
+}
 
 export const sexGroupOrder = {
   [sexGroups.B]: 0,

--- a/src/ui/filter.js
+++ b/src/ui/filter.js
@@ -20,8 +20,9 @@ import {
   getOverrideText,
   getAgeAndSex,
   getAgeSex,
-  getSexDisplay,
-  DictTool
+  getSexDisplays as getSexDisplays,
+  DictTool,
+  SetTools
 } from "../util/data.js";
 import { getCompositeInfo } from "../util/graph.js";
 import { NumberTool } from "../util/data.js";
@@ -115,8 +116,9 @@ function getAgeSexGroup(graphType) {
       const ageSexGroup = getAgeSex(age, sex);
       if (!(ageSexGroup in ageSexGroups)) continue;
       
-      const sexDisplay = getSexDisplay(sex, age);
-      if (!sexOptions.has(sexDisplay)) continue;
+      const sexDisplays = getSexDisplays(sex, age);
+      const hasSexDisplays = SetTools.intersection(sexOptions, sexDisplays);
+      if (hasSexDisplays.size == 0) continue;
 
       result.push(ageSexGroup);
     }
@@ -332,18 +334,21 @@ function addEventListenersToFilters() {
       for (const sexKey in sexGroups) {
         const sex = sexGroups[sexKey];
         const ageSexGroup = getAgeSex(age, sex);
-        const sexDisplay = getSexDisplay(sex, age);
+
+        const sexDisplays = getSexDisplays(sex, age);
 
         if (!(ageSexGroup in ageSexGroups)) {
           if (selectedSexes.has(sex)) {
             selectedSexes.delete(sex);
-            selectedSexOptions.delete(sexDisplay);
+            SetTools.difference([selectedSexOptions, sexDisplays], false);
           }
 
           continue;
         }
 
-        availableSexes[sexDisplay] = sex;
+        for (const sexDisplay of sexDisplays) {
+          availableSexes[sexDisplay] = sex;
+        }
       }
     }
 
@@ -719,10 +724,12 @@ function displayRbfgAgeSexGroupFilter() {
 
   for (const ageSexGroup in ageSexGroups) {
     const [age, sex] = getAgeAndSex(ageSexGroup);
-    const sexDisplay = getSexDisplay(sex, age);
-
     ages.add(age);
-    sexes[sexDisplay] = sex;
+
+    const sexDisplays = getSexDisplays(sex, age);
+    for (const sexDisplay of sexDisplays) {
+      sexes[sexDisplay] = sex;
+    }
   }
 
   ages = Array.from(ages);

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -7,7 +7,9 @@ import {
   sexGroups,
   getTranslations,
   ageGroups1To8,
-  Translation
+  Translation,
+  ageSuperGroups,
+  ageSuperGroupsByAgeGroup
 } from "../const.js";
 
 
@@ -79,6 +81,68 @@ export class DictTool {
 }
 
 
+// SetTools: Class for handling with Sets
+//     This class is mostly used to deal with compatibility issues with older browsers
+//     since some of Javascript's Set functions are only recently implemented in 2023-2024
+export class SetTools {
+
+    // difference(sets, newCopy): Computes the set difference of set1 - set2
+    // Note:
+    //  If 'newCopy' is set to false, the result for the set difference is stored
+    //      at the first set of 'sets'
+    static difference(sets, newCopy = false) {
+        if (sets.length < 1) return new Set();
+        const result = newCopy ? new Set(sets[0]) : sets[0];
+
+        for (let i = 1; i < sets.length; ++i) {
+            const currentSet = sets[i];
+            for (const element of currentSet) {
+                result.delete(element);
+            }
+        }
+
+        return result;
+    }
+
+    // intersection(set1, set2): Computes the set intersection of set1 ∩ set2
+    static intersection(set1, set2) { 
+        const result = new Set(); 
+        for (let element of set2) { 
+            if (set1.has(element)) { 
+                result.add(element); 
+            } 
+        } 
+
+        return result; 
+    }
+
+    // union(set1, set2, neweCopy): Computes the union of set1 U set2
+    static union(set1, set2, newCopy = false) {
+        const result = newCopy ? new Set(set1) : set1;
+        for (const element of set2) {
+            result.add(element);
+        }
+
+        return result;
+    }
+
+    // filter(set, predicate, newCopy): filters a set
+    static filter(set, predicate, newCopy = false) {
+        const result = newCopy ? new Set() : set;
+        for (const element of set) {
+            const inFilter = predicate(element);
+            if (newCopy && inFilter) {
+                result.add(element);
+            } else if (!newCopy && !inFilter) {
+                result.delete(element);
+            }
+        }
+
+        return result;
+    }
+}
+
+
 /**
  * Return domain specific age-sex group, age group, and sex group from age-sex group found in raw consumption entry
  */
@@ -136,11 +200,22 @@ export function getAgeAndSex(ageSexGroup) {
   return ageSexGroup.split(" ", 2);
 }
 
-// getSexDisplay: Retrieves the display for a particular sex
-export function getSexDisplay(sex, age) {
-  if (sex != sexGroups.B) return Translation.translate(`misc.sexGroups.${sex}`);
-  if (ageGroups1To8.has(age)) return Translation.translate(`misc.sexGroups.Both1To8`);
-  return Translation.translate(`misc.sexGroups.Both9Plus`);
+// getSexDisplays: Retrieves the displays for a particular sex
+export function getSexDisplays(sex, age) {
+  if (sex != sexGroups.B) return new Set(Translation.translate(`misc.sexGroups.${sex}`));
+
+  const currentAgeSuperGroups = ageSuperGroupsByAgeGroup[age];
+  const result = [];
+
+  for (const ageSuperGroup of currentAgeSuperGroups) {
+    if (ageSuperGroup == ageSuperGroups.Age1To8) {
+      result.push(Translation.translate(`misc.sexGroups.Both1To8`));
+    } else if (ageSuperGroup == ageSuperGroups.Age9Plus) {
+      result.push(Translation.translate(`misc.sexGroups.Both9Plus`));
+    }
+  }
+
+  return new Set(result);
 }
 
 /**


### PR DESCRIPTION
- For age groups such as `1-8` and `1+` that overlap between the ranges of age `1-8` and age `9+`, want to show both:
   - `M/F (1-8 yrs)` AND
   - `M/F (9+ yrs)`