### PR TITLE
Format exposure estimate to scientific notation for radionuclide in table of the website

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -664,6 +664,14 @@ export class Translation {
       return this.translate("Number", translateArgs);
   }
 
+  // translateScientificNum(numStr, decimalPlaces): Translates a number to its scientific notation
+  static translateScientificNum(numStr, decimalPlaces = 1) {
+    let result = Number.parseFloat(numStr).toExponential(decimalPlaces);
+    return result.replace(/[0-9]+(.[0-9]+)?/, function(match) {
+        return Translation.translateNum(match, decimalPlaces);
+    })
+  }
+
   // clearTranslationCache(): Clears any cached data related to translations
   static clearTranslationCache() {
     WebNotesCache = {};
@@ -694,6 +702,8 @@ const LangEN = {
   /**
    * Introductory Text
    */
+
+  Number: "{{num, number}}",
 
   "websiteTabTitle": "Canadian Total Diet Study 2008-2023 Dietary Exposure Tool",
   "changeLanguage": "Français",
@@ -1381,6 +1391,8 @@ French
 const REMPLACER_MOI = "REMPLACER MOI"
 
 const LangFR = {
+  Number: "{{num, number}}",
+
   "websiteTabTitle": "Outil d'exposition alimentaire de l'Étude canadienne sur l'alimentation totale 2008-2023",
   "changeLanguage": "English",
   "changeLanguageValue": language.EN,

--- a/src/ui/dataTableComponent.js
+++ b/src/ui/dataTableComponent.js
@@ -145,6 +145,16 @@ export async function displayDataTable(data, filters) {
       return {"title": headerTranslations[columnKey], "data": columnKey};
   });
 
+  // any display adjustments to the data
+  if (filters.chemicalGroup.trim() == Translation.translate("tdsData.values.radionuclides")) {
+    for (const row of data) {
+      const exposure = row[DataTableHeader.EXPOSURE];
+      if (exposure == undefined) continue;
+
+      row[DataTableHeader.EXPOSURE] = Translation.translateScientificNum(exposure);
+    }
+  }
+
   updateTable(tableId, tableColInfo, data);
 
   // adjust the column widths


### PR DESCRIPTION
- For French, the decimal points are converted to commas