### PR TITLE
Add table chemical breakdown for exposure in total radionuclides

### DIFF
--- a/src/data/dataTranslator.js
+++ b/src/data/dataTranslator.js
@@ -21,6 +21,9 @@ import {
   getOccurrenceForContaminantEntry,
   getUnitForContaminantEntry,
   getYearForContaminantEntry,
+  DictTools,
+  formatNumber,
+  formatPercent
 } from "../util/data.js";
 import { getActiveFilters } from "../ui/filter.js";
 
@@ -380,4 +383,41 @@ export async function getRawFilteredContaminantData() {
 
   data.csvFilename = formatDownloadName(data.filename);
   return [data];
+}
+
+
+// groupContaminantsByChemical(contaminant): Groups the contaminants by their chemicals
+export function groupContaminantsByChecmical(contaminant) {
+  const result = {};
+
+  for (const year in contaminant) {
+    for (const row of contaminant[year]) {
+      const chemical = row.chemical;
+      if (result[chemical] == undefined) result[chemical] = {};
+      if (result[chemical][year] == undefined) result[chemical][year] = [];
+
+      result[chemical][year].push(row);
+    }
+  }
+
+  return result;
+}
+
+// breakDownFormatNumbers(breakDown, filters): Formats all the values in some breakdown in a table cell to numbers
+export function breakDownFormatNumbers(breakDown, filters) {
+    for (const key in breakDown) {
+      breakDown[key] = formatNumber(breakDown[key], filters);
+    }
+
+    return breakDown;
+}
+
+// getBreakdownDistribution(breakdown): Retrieves the distribution from some breakdown in some cell of a table
+export function getBreakdownDistribution(breakDown) {
+    let distribution = DictTools.getDistribution(breakDown);
+    for (const chemical in distribution) {
+      distribution[chemical] = formatPercent(distribution[chemical] *  100);
+    }
+
+    return DictTools.merge([breakDown, distribution], {0: "value", 1: "distribution"});
 }

--- a/src/graph/rbfg.js
+++ b/src/graph/rbfg.js
@@ -5,47 +5,30 @@ import {
   MeanFlag,
   RbfgRangeFormat,
   ageGroups,
-  getTranslations
+  getTranslations,
+  Translation
 } from "../const.js";
 import {
+  DictTools,
   formatNumber,
   formatPercent,
   getAgeAndSex,
   getAgeSexDisplay,
   getExposureUnit,
   getUserModifiedValueText,
+  SetTools
 } from "../util/data.js";
 import {
   getCompositeInfo,
   getContaminantExposure,
   getOccurrenceForContaminantEntry,
 } from "../util/graph.js";
+import { breakDownFormatNumbers, getBreakdownDistribution, groupContaminantsByChecmical } from "../data/dataTranslator.js";
 
-/**
- * Take in TDS data and return data which has been strictly filtered and formatted
- * for use when comparing results by food group
- *
- * Returns:
- * - An object with following properties:
- *  - Age-sex group
- *    - Food group
- *      - ageSexGroup
- *      - consumptionsFlagged: array of food composite descriptons
- *      - consumptionsSuppressed: array of food composite descriptons
- *      - consumptionsSuppressedWithHighCv: array of food composite descriptions
- *      - contaminantUnit
- *      - exposure
- *      - foodGroup
- *      - numContaminantsTested
- *      - numCompositesTested
- *      - numContaminantsUnderLod
- *      - percentExposure
-        - percentNotTested
- *      - percentUnderLod
- *    // other food groups
- *  // other age-sex groups
- */
-export function getRbfg(tdsData, filters) {
+
+// getChemicalRbfg(tdsData, filters): Retrieves the data for results by age-sex group
+//  for a particular chemical
+function getChemicalRbfg(tdsData, filters) {
   const rbfgData = {};
   filters.ageSexGroups.forEach((ageSexGroup) => (rbfgData[ageSexGroup] = {}));
 
@@ -77,25 +60,18 @@ export function getRbfg(tdsData, filters) {
       if (consumptions.length == 0) return;
 
       consumptions.forEach((consumption) => {
-        const consumptionMeanFlag = filters.usePerPersonPerDay
-          ? consumption.meanFlagForPerPersonPerDay
-          : consumption.meanFlagForPerKgBWPerDay;
+        const consumptionMeanFlag = filters.usePerPersonPerDay ? consumption.meanFlagForPerPersonPerDay : consumption.meanFlagForPerKgBWPerDay;
         const compositeInfo = getCompositeInfo(consumption);
+
         if (consumptionMeanFlag == MeanFlag.SUPPRESSED) {
-          rbfgData[consumption.ageSexGroup][
-            foodGroup
-          ].consumptionsSuppressed.push(compositeInfo);
+          rbfgData[consumption.ageSexGroup][foodGroup].consumptionsSuppressed.push(compositeInfo);
+
         } else if (consumptionMeanFlag == MeanFlag.FLAGGED) {
-          rbfgData[consumption.ageSexGroup][foodGroup].consumptionsFlagged.push(
-            compositeInfo,
-          );
+          rbfgData[consumption.ageSexGroup][foodGroup].consumptionsFlagged.push(compositeInfo);
+
         } else if (consumptionMeanFlag == MeanFlag.SUPPRESSED_HIGH_CV) {
-          rbfgData[consumption.ageSexGroup][
-            foodGroup
-          ].consumptionsSuppressed.push(compositeInfo);
-          rbfgData[consumption.ageSexGroup][
-            foodGroup
-          ].consumptionsSuppressedWithHighCv.push(compositeInfo);
+          rbfgData[consumption.ageSexGroup][foodGroup].consumptionsSuppressed.push(compositeInfo);
+          rbfgData[consumption.ageSexGroup][foodGroup].consumptionsSuppressedWithHighCv.push(compositeInfo);
         }
 
         let numContaminantsTested = 0;
@@ -103,19 +79,19 @@ export function getRbfg(tdsData, filters) {
         let sumContaminantsTested = 0;
 
         filters.years.forEach((year) => {
+          if (tdsData.contaminant[year] == undefined) return;
+
           tdsData.contaminant[year].forEach((contaminant) => {
             if (contaminant.compositeInfo.includes(composite)) {
               if (filters.lod != LODs.Exclude || contaminant.occurrence != 0) {
                 numContaminantsTested++;
               }
-              sumContaminantsTested += getOccurrenceForContaminantEntry(
-                contaminant,
-                filters,
-              );
+
+              sumContaminantsTested += getOccurrenceForContaminantEntry(contaminant, filters);
               compositeTested = 1;
+
               if (contaminant.occurrence < contaminant.lod) {
-                rbfgData[consumption.ageSexGroup][foodGroup]
-                  .numContaminantsUnderLod++;
+                rbfgData[consumption.ageSexGroup][foodGroup].numContaminantsUnderLod++;
               }
             }
           });
@@ -148,28 +124,9 @@ export function getRbfg(tdsData, filters) {
         );
 
         rbfgData[consumption.ageSexGroup][foodGroup].exposure += exposure;
-        rbfgData[consumption.ageSexGroup][foodGroup].numContaminantsTested +=
-          numContaminantsTested;
-        rbfgData[consumption.ageSexGroup][foodGroup].numCompositesTested +=
-          compositeTested;
+        rbfgData[consumption.ageSexGroup][foodGroup].numContaminantsTested += numContaminantsTested;
+        rbfgData[consumption.ageSexGroup][foodGroup].numCompositesTested += compositeTested;
       });
-    });
-  });
-
-  Object.keys(rbfgData).forEach((ageSexGroup) => {
-    const sumExposures = Object.values(rbfgData[ageSexGroup]).reduce(
-      (acc, b) => acc + b.exposure,
-      0,
-    );
-    Object.values(rbfgData[ageSexGroup]).forEach((row) => {
-      row.percentExposure = (row.exposure / sumExposures) * 100 || 0;
-      row.percentUnderLod =
-        (row.numContaminantsUnderLod / row.numContaminantsTested) * 100 || 0;
-      const numComposites = Object.values(
-        tdsData.consumption[row.foodGroup],
-      ).length;
-      row.percentNotTested =
-        ((numComposites - row.numCompositesTested) / numComposites) * 100;
     });
   });
 
@@ -188,6 +145,87 @@ export function getRbfg(tdsData, filters) {
   return rbfgData;
 }
 
+function getRbfgAggregates(rbfgData, tdsData) {
+  const sumExposures = {};
+
+  // retrieve the sum of the exposures
+  for (const chemical in rbfgData) {
+    const chemicalRbfgData = rbfgData[chemical];
+    
+    for (const ageSexGroup in chemicalRbfgData) {
+      if (sumExposures[ageSexGroup] == undefined) sumExposures[ageSexGroup] = 0;
+      sumExposures[ageSexGroup] += Object.values(chemicalRbfgData[ageSexGroup]).reduce((acc, b) => acc + b.exposure, 0);
+    }
+  }
+
+  for (const chemical in rbfgData) {
+    const chemicalRbfgData = rbfgData[chemical];
+
+    for (const ageSexGroup in chemicalRbfgData) {
+      const ageChemicalRbfgData = chemicalRbfgData[ageSexGroup];
+
+      for (const foodGroup in ageChemicalRbfgData) {
+        const row = ageChemicalRbfgData[foodGroup];
+        const sumExposure = sumExposures[ageSexGroup];
+        row.percentExposure = (row.exposure / sumExposure) * 100 || 0;
+        row.percentUnderLod = (row.numContaminantsUnderLod / row.numContaminantsTested) * 100 || 0;
+
+        const numComposites = Object.values(tdsData.consumption[row.foodGroup]).length;
+        row.percentNotTested = ((numComposites - row.numCompositesTested) / numComposites) * 100;
+      }
+    }
+  }
+
+  return rbfgData;
+}
+
+/**
+ * Take in TDS data and return data which has been strictly filtered and formatted
+ * for use when comparing results by food group
+ *
+ * Returns:
+ * - An object with following properties:
+ *  - Age-sex group
+ *    - Food group
+ *      - ageSexGroup
+ *      - consumptionsFlagged: array of food composite descriptons
+ *      - consumptionsSuppressed: array of food composite descriptons
+ *      - consumptionsSuppressedWithHighCv: array of food composite descriptions
+ *      - contaminantUnit
+ *      - exposure
+ *      - foodGroup
+ *      - numContaminantsTested
+ *      - numCompositesTested
+ *      - numContaminantsUnderLod
+ *      - percentExposure
+        - percentNotTested
+ *      - percentUnderLod
+ *    // other food groups
+ *  // other age-sex groups
+ */
+export function getRbfg(tdsData, filters) {
+  let result = {};
+  if (filters.chemical != Translation.translate("tdsData.values.totalRadionuclides")) {
+    result = getChemicalRbfg(tdsData, filters);
+    result = getRbfgAggregates({[filters.chemical]: result}, tdsData);
+    return result[filters.chemical];
+  }
+
+  const allContaminants = tdsData.contaminant;
+  const groupedContaminants = groupContaminantsByChecmical(tdsData.contaminant);
+  const currentFilters = structuredClone(filters);
+
+  for (const chemical in groupedContaminants) {
+    currentFilters.chemical = chemical;
+    tdsData.contaminant = groupedContaminants[chemical];
+    result[chemical] = getChemicalRbfg(tdsData, currentFilters);
+  }
+
+  tdsData.contaminant = allContaminants;
+  result = getRbfgAggregates(result, tdsData);
+  return result;
+}
+
 /**
  * Take in data formatted for comparing results by food group (see function above) and format it to a data table format
  *
@@ -195,41 +233,92 @@ export function getRbfg(tdsData, filters) {
  * - An array of objects adhering to the contract specified in the displayDataTable function of dataTableComponent.js
  */
 export function formatRbfgToDataTable(rbfgData, filters) {
-  const dataTableData = [];
+  const dataTableData = {};
+  const isRadionuclide = filters.chemicalGroup.trim() == Translation.translate("tdsData.values.radionuclides");
+  const isTotalRadionuclide = filters.chemical == Translation.translate("tdsData.values.totalRadionuclides");
 
-  Object.values(rbfgData).forEach((ageSexGroup) => {
-    Object.values(ageSexGroup).forEach((row) => {
-      dataTableData.push({
-        [DataTableHeader.CHEMICAL]: filters.chemical,
-        [DataTableHeader.AGE_SEX_GROUP]: getAgeSexDisplay(row.ageSexGroup),
-        [DataTableHeader.FOOD_GROUP]: row.foodGroup,
-        [DataTableHeader.PERCENT_EXPOSURE]: formatPercent(row.percentExposure),
-        [DataTableHeader.EXPOSURE]: formatNumber(row.exposure, filters),
-        [DataTableHeader.EXPOSURE_UNIT]: getExposureUnit(
-          row.contaminantUnit,
-          filters,
-        ),
-        [DataTableHeader.YEARS]: filters.years.join(", "),
-        [DataTableHeader.PERCENT_NOT_TESTED]: formatPercent(
-          row.percentNotTested,
-        ),
-        [DataTableHeader.PERCENT_UNDER_LOD]: formatPercent(row.percentUnderLod),
-        [DataTableHeader.TREATMENT]: filters.lod,
-        [DataTableHeader.MODIFIED]: filters.override.list
-          .filter((override) => override.foodGroup == row.foodGroup)
-          .map((override) =>
-            getUserModifiedValueText(override, row.contaminantUnit),
-          )
-          .join("; "),
-        [DataTableHeader.FLAGGED]: row.consumptionsFlagged.join("; "),
-        [DataTableHeader.SUPPRESSED]: row.consumptionsSuppressed.join("; "),
-        [DataTableHeader.INCLUDED_SUPPRESSED]: filters.useSuppressedHighCvValues
-          ? row.consumptionsSuppressedWithHighCv.join("; ")
-          : [],
+  if (!isTotalRadionuclide) {
+    rbfgData = {[filters.chemical]: rbfgData};
+  }
+
+  for (const chemical in rbfgData) {
+    const chemicalRbfgData = rbfgData[chemical];
+
+    Object.values(chemicalRbfgData).forEach((ageSexGroup) => {
+      Object.values(ageSexGroup).forEach((row) => {
+        if (!row.ageSexGroup) return;
+
+        let foodGroupRow = dataTableData[row.foodGroup];
+        if (foodGroupRow == undefined) {
+          foodGroupRow = {};
+          dataTableData[row.foodGroup] = foodGroupRow;
+        }
+
+        const dataTableRow = foodGroupRow[row.ageSexGroup];
+        if (dataTableRow == undefined) {
+          foodGroupRow[row.ageSexGroup] = {
+            [DataTableHeader.CHEMICAL]: filters.chemical,
+            [DataTableHeader.AGE_SEX_GROUP]: getAgeSexDisplay(row.ageSexGroup),
+            [DataTableHeader.FOOD_GROUP]: row.foodGroup,
+            [DataTableHeader.PERCENT_EXPOSURE]: {[chemical]: formatPercent(row.percentExposure)},
+            [DataTableHeader.EXPOSURE]: {[chemical]: row.exposure},
+            [DataTableHeader.EXPOSURE_UNIT]: {[chemical]: getExposureUnit(row.contaminantUnit, filters)},
+            [DataTableHeader.YEARS]: new Set(row.years),
+            [DataTableHeader.PERCENT_NOT_TESTED]: {[chemical]: formatPercent(row.percentNotTested)},
+            [DataTableHeader.PERCENT_UNDER_LOD]: {[chemical]: formatPercent(row.percentUnderLod)},
+            [DataTableHeader.TREATMENT]: filters.lod,
+            [DataTableHeader.MODIFIED]: filters.override.list.filter((override) => override.foodGroup == row.foodGroup).map((override) => getUserModifiedValueText(override, row.contaminantUnit)).join("; "),
+            [DataTableHeader.FLAGGED]: new Set(row.consumptionsFlagged),
+            [DataTableHeader.SUPPRESSED]: new Set(row.consumptionsSuppressed),
+            [DataTableHeader.INCLUDED_SUPPRESSED]: new Set(filters.useSuppressedHighCvValues ? row.consumptionsSuppressedWithHighCv : [])
+          };
+
+          return;
+        }
+
+        dataTableRow[DataTableHeader.PERCENT_EXPOSURE][chemical] = formatPercent(row.percentExposure);
+        dataTableRow[DataTableHeader.EXPOSURE][chemical] = row.exposure;
+        dataTableRow[DataTableHeader.EXPOSURE_UNIT][chemical] = getExposureUnit(row.contaminantUnit, filters);
+        SetTools.union(dataTableRow[DataTableHeader.YEARS], new Set(row.years), false);
+        dataTableRow[DataTableHeader.PERCENT_NOT_TESTED][chemical] = formatPercent(row.percentNotTested);
+        dataTableRow[DataTableHeader.PERCENT_UNDER_LOD][chemical] = formatPercent(row.percentUnderLod);
+        SetTools.union(dataTableRow[DataTableHeader.FLAGGED], new Set(row.consumptionsFlagged), false);
+        SetTools.union(dataTableRow[DataTableHeader.SUPPRESSED], new Set(row.consumptionsSuppressed), false);
+        SetTools.union(dataTableRow[DataTableHeader.INCLUDED_SUPPRESSED], new Set(filters.useSuppressedHighCvValues ? row.consumptionsSuppressedWithHighCv : []));
       });
     });
-  });
-  return dataTableData;
+  }
+  
+  let result = [];
+  for (const foodGroup in dataTableData) {
+    result = result.concat(Object.values(dataTableData[foodGroup]));
+  }
+
+  for (const row of result) {
+    if (!isTotalRadionuclide) {
+      row[DataTableHeader.EXPOSURE] = formatNumber(row[DataTableHeader.EXPOSURE][filters.chemical], filters);
+    } else {
+      row[DataTableHeader.EXPOSURE] = getBreakdownDistribution(row[DataTableHeader.EXPOSURE]);
+    }
+
+    row[DataTableHeader.PERCENT_EXPOSURE] = DictTools.toWebStr(row[DataTableHeader.PERCENT_EXPOSURE]);
+    row[DataTableHeader.EXPOSURE_UNIT] = DictTools.toWebStr(row[DataTableHeader.EXPOSURE_UNIT]);
+    row[DataTableHeader.PERCENT_NOT_TESTED] = DictTools.toWebStr(row[DataTableHeader.PERCENT_NOT_TESTED]);
+    row[DataTableHeader.PERCENT_UNDER_LOD] = DictTools.toWebStr(row[DataTableHeader.PERCENT_UNDER_LOD]);
+
+    row[DataTableHeader.YEARS] = Array.from(row[DataTableHeader.YEARS]).join(", ");
+    row[DataTableHeader.FLAGGED] = Array.from(row[DataTableHeader.FLAGGED]).join("; ");
+    row[DataTableHeader.SUPPRESSED] = Array.from(row[DataTableHeader.SUPPRESSED]).join("; ");
+    row[DataTableHeader.INCLUDED_SUPPRESSED] = Array.from(row[DataTableHeader.INCLUDED_SUPPRESSED]).join("; ");
+  }
+
+  return result;
+}
+
+function getRbfgGraphInfo(filters, exposure, ageSexGroup, foodGroup) {
+  return foodGroup + `(${getAgeSexDisplay(ageSexGroup)})\n` +
+         Translation.translate(`graphs.${GraphTypes.RBFG}.range.${filters.usePercent ? RbfgRangeFormat.PERCENT : RbfgRangeFormat.NUMBER}`) + ": " +
+        (filters.usePercent ? formatPercent(exposure): formatNumber(exposure, filters) + " " + getExposureUnit(contaminantUnit, filters));
 }
 
 /**
@@ -243,9 +332,12 @@ export function formatRbfgToStackedBar(rbfgData, filters, colorMapping) {
     return {};
   }
 
-  const contaminantUnit = Object.values(Object.values(rbfgData)[0])[0]
-    .contaminantUnit;
+  const isTotalRadionuclide = filters.chemical == Translation.translate("tdsData.values.totalRadionuclides");
+  if (!isTotalRadionuclide) {
+    rbfgData = {[filters.chemical]: rbfgData};
+  }
 
+  const contaminantUnit = Object.values(Object.values(Object.values(rbfgData)[0])[0])[0].contaminantUnit;
   const stackedBarData = {
     children: [],
     titleY: `${
@@ -256,38 +348,47 @@ export function formatRbfgToStackedBar(rbfgData, filters, colorMapping) {
     titleX: getTranslations().graphs[GraphTypes.RBFG].domain,
   };
 
-  Object.keys(rbfgData).forEach((ageSexGroup) => {
-    Object.keys(rbfgData[ageSexGroup]).forEach((foodGroup) => {
-      const [age, sexGroup] = getAgeAndSex(getAgeSexDisplay(ageSexGroup));
-      const exposure =
-        (filters.usePercent
-          ? rbfgData[ageSexGroup][foodGroup].percentExposure || 0
-          : rbfgData[ageSexGroup][foodGroup].exposure) || 0;
-      stackedBarData.children.push({
-        entry: age + sexGroup,
-        sortBy: Object.keys(ageGroups).indexOf(ageSexGroup),
-        color: colorMapping[foodGroup].color,
-        stack: foodGroup,
-        value: exposure,
-        info:
-          foodGroup +
-          " (" +
-          getAgeSexDisplay(ageSexGroup) +
-          ")\n" +
-          getTranslations().graphs[GraphTypes.RBFG].range[
-            filters.usePercent
-              ? RbfgRangeFormat.PERCENT
-              : RbfgRangeFormat.NUMBER
-          ] +
-          ": " +
-          (filters.usePercent
-            ? formatPercent(exposure)
-            : formatNumber(exposure, filters) +
-              " " +
-              getExposureUnit(contaminantUnit, filters)),
+  const graphData = {};
+
+  for (const chemical in rbfgData) {
+    const chemicalRbfgData = rbfgData[chemical];
+
+    Object.keys(chemicalRbfgData).forEach((ageSexGroup) => {
+      Object.keys(chemicalRbfgData[ageSexGroup]).forEach((foodGroup) => {
+        const [age, sexGroup] = getAgeAndSex(getAgeSexDisplay(ageSexGroup));
+
+        if (graphData[foodGroup] == undefined) {
+          graphData[foodGroup] = {};
+        }
+
+        const graphDataId = `${age}${sexGroup}`;
+        const graphDataEntry = graphData[foodGroup][graphDataId];
+
+        const exposure = (filters.usePercent
+            ? chemicalRbfgData[ageSexGroup][foodGroup].percentExposure || 0
+            : chemicalRbfgData[ageSexGroup][foodGroup].exposure) || 0;
+
+        if (graphDataEntry == undefined) {
+          graphData[foodGroup][graphDataId] = {
+            entry: age + sexGroup,
+            sortBy: Object.keys(ageGroups).indexOf(ageSexGroup),
+            color: colorMapping[foodGroup].color,
+            stack: foodGroup,
+            value: exposure,
+            info: getRbfgGraphInfo(filters, exposure, ageSexGroup, foodGroup)
+          }
+          return;
+        }
+
+        graphDataEntry.value += exposure;
+        graphDataEntry.info = getRbfgGraphInfo(filters, exposure, ageSexGroup, foodGroup);
       });
     });
-  });
+  }
+
+  for (const foodGroup in graphData) {
+    stackedBarData.children = stackedBarData.children.concat(Object.values(graphData[foodGroup]));
+  }
 
   return stackedBarData;
 }

--- a/src/ui/dataTableComponent.js
+++ b/src/ui/dataTableComponent.js
@@ -9,7 +9,7 @@ import { formatRbfToDataTable, getRbf } from "../graph/rbf.js";
 import { formatRbfgToDataTable, getRbfg } from "../graph/rbfg.js";
 import { el} from "./const.js";
 import { getActiveFilters } from "./filter.js";
-import { TableTools } from "../util/data.js";
+import { DictTools, TableTools } from "../util/data.js";
 
 /**
  * Download raw filtered TDS data
@@ -168,7 +168,19 @@ export async function displayDataTable(data, filters) {
       const exposure = row[DataTableHeader.EXPOSURE];
       if (exposure == undefined) continue;
 
-      row[DataTableHeader.EXPOSURE] = Translation.translateScientificNum(exposure);
+      if (exposure.constructor != Object) {
+        row[DataTableHeader.EXPOSURE] = Translation.translateScientificNum(exposure);
+        continue;
+      }
+
+      const display = {};
+      for (const chemical in exposure) {
+        const chemicalExposure = exposure[chemical];
+        chemicalExposure["value"] = Translation.translateScientificNum(chemicalExposure["value"]);
+        display[chemical] = `${chemicalExposure["value"]} (${chemicalExposure["distribution"]})`;
+      }
+  
+      row[DataTableHeader.EXPOSURE] = DictTools.toStr(display, "<br>");
     }
   }
 

--- a/src/ui/filter.js
+++ b/src/ui/filter.js
@@ -21,7 +21,7 @@ import {
   getAgeAndSex,
   getAgeSex,
   getSexDisplays as getSexDisplays,
-  DictTool,
+  DictTools,
   SetTools
 } from "../util/data.js";
 import { getCompositeInfo } from "../util/graph.js";
@@ -745,7 +745,7 @@ function displayRbasgSexFilter(sexes, selected = undefined) {
   dropdown.selectpicker('destroy');
 
   sexGroupEl.innerHTML = "";
-  sexes = DictTool.getMapSorted(sexes, compareSex);
+  sexes = DictTools.getMapSorted(sexes, compareSex);
 
   for (const [sexDisplay, sex] of sexes) {
     const oe = document.createElement("option");
@@ -845,7 +845,7 @@ function displayRbfgSexFilter(sexes, selected = undefined) {
   dropdown.selectpicker('destroy');
 
   sexGroupEl.innerHTML = "";
-  sexes = DictTool.getMapSorted(sexes, compareSex);
+  sexes = DictTools.getMapSorted(sexes, compareSex);
 
   for (const [sexDisplay, sex] of sexes) {
     const oe = document.createElement("option");

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -63,7 +63,7 @@ export class NumberTool {
 
 
 // DictTool: Tools for handling dictionaries
-export class DictTool {
+export class DictTools {
 
   // getMapSorted(dict, compareFn): Retrieves a corresponding map
   //  to the sorted dictionarys
@@ -74,6 +74,63 @@ export class DictTool {
     const result = new Map();
     for (const key of keys) {
       result.set(key, dict[key]);
+    }
+
+    return result;
+  }
+
+  // toStr(dict, end): Converts a dictionary to a string
+  static toStr(dict, end = "\n") {
+    let result = [];
+    for (const key in dict) {
+      result.push(`${key}: ${dict[key]}`);
+    }
+
+    return result.join(end);
+  }
+
+  // toWebStr(dict): Converts a dictionary to a string to be displayed on a webpage
+  static toWebStr(dict) {
+    const dictKeys = Object.keys(dict);
+    const dictLen = dictKeys.length;
+    
+    if (dictLen == 0) return "";
+    else if (dictLen > 1) return DictTools.toStr(dict, "<br>");
+    return dict[dictKeys[0]];
+  }
+
+  // merge(dicts, keys): Merges multiple dictionaries toghether
+  static merge(dicts, keys = null) {
+    const result = {};
+    const dictsLen = dicts.length;
+
+    for (let i = 0; i < dictsLen; ++i) {
+      const dict = dicts[i];
+
+      for (const key in dict) {
+        if (result[key] == undefined) {
+          result[key] = keys == null ? [] : {};
+        }
+
+        if (keys == null) {
+          result[key].push(dict[key]);
+        } else {
+          const dictKey = keys[i];
+          result[key][dictKey] = dict[key];
+        }
+      }
+    }
+
+    return result;
+  }
+
+  // getDistribution(dict): Retrieves a probability distribution for a given values
+  static getDistribution(dict) {
+    const total = Object.values(dict).reduce((acc, prob) => acc + prob);
+    const result = {};
+
+    for (const key in dict) {
+      result[key] = total != 0 ? dict[key] / total : 0;
     }
 
     return result;


### PR DESCRIPTION
- For `Total Radionuclides`, table only shows result of "total radionuclide" instead of each individual chemical
- Exposure in table has breakdown by chemical

> [!WARNING]
>- For now, other unspecified columns also use the type of chemical breakdown as exposure