### PR TITLE
Fix percentage calculation denominator of total radionuclides and add total breakdown line

### DIFF
--- a/src/const.js
+++ b/src/const.js
@@ -651,7 +651,7 @@ export class Translation {
   //
   // Note:
   //  See https://www.i18next.com/translation-function/formatting for more formatting
-  static translateNum(numStr, decimalPlaces = 1) {
+  static translateNum(numStr, decimalPlaces = 2) {
       let num = Number(numStr);
       if (Number.isNaN(num)) return numStr;
 
@@ -994,6 +994,8 @@ const LangEN = {
     values: {
       occurrence: "Occurrence",
     },
+
+    breakDownTotal: "{{ totalVal }} ({{ totalPercent }}%) from:"
   },
 
   /**
@@ -1693,6 +1695,8 @@ const LangFR = {
     values: {
       occurrence: "Occurrence",
     },
+
+    breakDownTotal: "{{ totalVal }} ({{ totalPercent }}%) de:"
   },
 
   about: {

--- a/src/data/dataTranslator.js
+++ b/src/data/dataTranslator.js
@@ -421,3 +421,42 @@ export function getBreakdownDistribution(breakDown) {
 
     return DictTools.merge([breakDown, distribution], {0: "value", 1: "distribution"});
 }
+
+// getBreakdownWebStr(breakdown, includeTotal): Retrieves the string representation of some breakdown in some cell of a table
+export function getBreakdownWebStr({breakDown, includeTotal = true, formatValFunc = null}) {
+  if (formatValFunc == null) {
+    formatValFunc = (key, val) => val;
+  }
+
+  let result = DictTools.toWebStr(breakDown, formatValFunc);
+  if (!includeTotal) return result;
+
+  let totalValue = Object.values(breakDown).reduce((acc, currentVal) => acc + currentVal, 0);
+  totalValue = formatValFunc("total", totalValue);
+
+  const totalLine = Translation.translate("dataTable.breakDownTotal", {totalVal: totalValue, totalPercent: 100});
+  return `<b>${totalLine}</b><br>${result}`;
+}
+
+// getBreakdownDistribWebStr(breakDown, getDistribution, includeTotal, formatValFunc): Retrieves the string representation of a breakdown and its distribution
+//  for some cell of a table
+export function getBreakdownDistribWebStr({breakDown, getDistribution = true, includeTotal = true, formatValFunc = null}) {
+  if (getDistribution) {
+    breakDown = getBreakdownDistribution(breakDown);
+  }
+
+  if (formatValFunc == null) {
+    formatValFunc = (key, val) => val;
+  }
+
+  const distribFormatFunc = (key, currentData) => `${formatValFunc(key, currentData.value)} (${currentData.distribution})`;
+
+  let result = DictTools.toWebStr(breakDown, distribFormatFunc);
+  if (!includeTotal) return result;
+
+  let totalValue = Object.values(breakDown).reduce((acc, currentVal) => acc + currentVal.value, 0);
+  totalValue = formatValFunc("total", totalValue);
+
+  const totalLine = Translation.translate("dataTable.breakDownTotal", {totalVal: totalValue, totalPercent: 100});
+  return `<b>${totalLine}</b><br>${result}`;
+}

--- a/src/ui/dataTableComponent.js
+++ b/src/ui/dataTableComponent.js
@@ -162,28 +162,6 @@ export async function displayDataTable(data, filters) {
       return {"title": headerTranslations[columnKey], "data": columnKey};
   });
 
-  // any display adjustments to the data
-  if (filters.chemicalGroup.trim() == Translation.translate("tdsData.values.radionuclides")) {
-    for (const row of data) {
-      const exposure = row[DataTableHeader.EXPOSURE];
-      if (exposure == undefined) continue;
-
-      if (exposure.constructor != Object) {
-        row[DataTableHeader.EXPOSURE] = Translation.translateScientificNum(exposure);
-        continue;
-      }
-
-      const display = {};
-      for (const chemical in exposure) {
-        const chemicalExposure = exposure[chemical];
-        chemicalExposure["value"] = Translation.translateScientificNum(chemicalExposure["value"]);
-        display[chemical] = `${chemicalExposure["value"]} (${chemicalExposure["distribution"]})`;
-      }
-  
-      row[DataTableHeader.EXPOSURE] = DictTools.toStr(display, "<br>");
-    }
-  }
-
   updateTable(tableId, tableColInfo, data);
 
   // adjust the column widths

--- a/src/ui/filter.js
+++ b/src/ui/filter.js
@@ -1161,6 +1161,8 @@ export function getFilteredTdsData() {
   });
 
   const filteredContaminantData = {};
+  let contaminantId = -1;
+
   Object.keys(filteredTdsData.contaminant).forEach((year) => {
     filteredContaminantData[year] = [];
     filters.override.list = filters.override.list.map((override) => {
@@ -1175,6 +1177,9 @@ export function getFilteredTdsData() {
           modifiedRow.occurrence = override.occurrence;
         }
       });
+
+      ++contaminantId;
+      modifiedRow.id = contaminantId;
       filteredContaminantData[year].push(modifiedRow);
     });
 
@@ -1182,6 +1187,8 @@ export function getFilteredTdsData() {
       if (override.entryFound) return;
 
       for (const chemical of chemicals) {
+        ++contaminantId;
+
         filteredContaminantData[year].push({
           chemical: chemical,
           chemicalGroup: filters.chemicalGroup,
@@ -1190,6 +1197,7 @@ export function getFilteredTdsData() {
           units: chemicalUnits[chemical],
           occurrence: override.occurrence,
           year: year,
+          id: contaminantId
         });
       }
     });

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -79,23 +79,27 @@ export class DictTools {
     return result;
   }
 
-  // toStr(dict, end): Converts a dictionary to a string
-  static toStr(dict, end = "\n") {
+  // toStr(dict, end, formatValFunc): Converts a dictionary to a string
+  static toStr({dict, end = "\n", formatValFunc = null}) {
     let result = [];
+    if (formatValFunc == null) {
+      formatValFunc = (key, val) => val;
+    }
+
     for (const key in dict) {
-      result.push(`${key}: ${dict[key]}`);
+      result.push(`${key}: ${formatValFunc(key, dict[key])}`);
     }
 
     return result.join(end);
   }
 
-  // toWebStr(dict): Converts a dictionary to a string to be displayed on a webpage
-  static toWebStr(dict) {
+  // toWebStr(dict, formatValFunc): Converts a dictionary to a string to be displayed on a webpage
+  static toWebStr(dict, formatValFunc = null) {
     const dictKeys = Object.keys(dict);
     const dictLen = dictKeys.length;
     
     if (dictLen == 0) return "";
-    else if (dictLen > 1) return DictTools.toStr(dict, "<br>");
+    else if (dictLen > 1) return DictTools.toStr({dict: dict, end: "<br>", formatValFunc: formatValFunc});
     return dict[dictKeys[0]];
   }
 
@@ -227,6 +231,30 @@ export class TableTools {
       }
 
       return result;
+  }
+
+    // _forGroup(ind, grouping, groupingOrder, func, keys, values): Internal function that iterates over a nested dictionary grouping
+  static _forGroup(ind, grouping, groupingOrder, func, keys, values) {
+      if (ind >= groupingOrder.length) {
+          func(keys, values);
+          return;
+      }
+
+      const groupName = groupingOrder[ind];
+      for (const groupKey in grouping) {
+          const groupVal = grouping[groupKey];
+          keys[groupName] = groupKey;
+          values[groupName] = groupVal;
+          this._forGroup(ind + 1, groupVal, groupingOrder, func, keys, values);
+      }
+  }
+
+  // forGroup(grouping, groupingOrder, func): Iterates over a nested dictionary grouping
+  //  (saves you time from writing up many nested for loops)
+  static forGroup(grouping, groupingOrder, func) {
+      const keys = {};
+      const values = {};
+      this._forGroup(0, grouping, groupingOrder, func, keys, values);
   }
 }
 


### PR DESCRIPTION
- For total radionuclides, the denominator of the current percentage calculations (`% foods not tested` and `% occurrence values`) is based on the particular chemical in the breakdown. The denominator should be based on all the radionuclides.

- Added line at the top of the radionuclide breakdown in the table to show the total of the breakdown