### PR TITLE
Limit breakdown to top 5 contributors

### DIFF
--- a/src/data/dataTranslator.js
+++ b/src/data/dataTranslator.js
@@ -423,24 +423,68 @@ export function getBreakdownDistribution(breakDown) {
 }
 
 // getBreakdownWebStr(breakdown, includeTotal): Retrieves the string representation of some breakdown in some cell of a table
-export function getBreakdownWebStr({breakDown, includeTotal = true, formatValFunc = null}) {
+export function getBreakdownWebStr({breakDown, includeTotal = true, formatValFunc = null, totalFormatValFunc = null,
+                                    sort = -1, limit = 5, getBreakdownVal = null}) {
   if (formatValFunc == null) {
     formatValFunc = (key, val) => val;
   }
 
-  let result = DictTools.toWebStr(breakDown, formatValFunc);
+  if (totalFormatValFunc === null) {
+    totalFormatValFunc = formatValFunc;
+  } else if (totalFormatValFunc === undefined) {
+    totalFormatValFunc = (key, val) => val;
+  }
+
+  if (getBreakdownVal == null) {
+    getBreakdownVal = (dict, key) => dict[key];
+  }
+
+  let newBreakdown = undefined;
+  let breakDownKeys = null;
+
+  // sorting
+  if (sort != 0 || limit !== null) {
+    breakDownKeys = Object.keys(breakDown);
+
+    if (sort != 0) {
+      const compareFn = (sort >= 0) ? (keyA, keyB) => getBreakdownVal(breakDown, keyA) - getBreakdownVal(breakDown, keyB) : (keyA, keyB) => getBreakdownVal(breakDown, keyB) - getBreakdownVal(breakDown, keyA)
+      breakDownKeys.sort(compareFn);
+    }
+  }
+
+  const breakDownFormatted = breakDownKeys !== null;
+
+  // limit entries
+  if (breakDownFormatted && limit !== null) {
+    breakDownKeys = breakDownKeys.slice(0, limit);
+  }
+
+  // create the new processed breakdown
+  if (breakDownFormatted) {
+    newBreakdown = new Map();
+    for (const key of breakDownKeys) {
+      newBreakdown.set(key, breakDown[key]);
+    }
+  } else {
+    newBreakdown = new Map(Object.entries(breakDown));
+  }
+
+  let result = DictTools.mapToWebStr(newBreakdown, formatValFunc);
   if (!includeTotal) return result;
 
-  let totalValue = Object.values(breakDown).reduce((acc, currentVal) => acc + currentVal, 0);
-  totalValue = formatValFunc("total", totalValue);
+  let totalValue = 0;
+  for (const key in breakDown) {
+    totalValue += getBreakdownVal(breakDown, key);
+  }
 
+  totalValue = totalFormatValFunc("total", totalValue);
   const totalLine = Translation.translate("dataTable.breakDownTotal", {totalVal: totalValue, totalPercent: 100});
   return `<b>${totalLine}</b><br>${result}`;
 }
 
 // getBreakdownDistribWebStr(breakDown, getDistribution, includeTotal, formatValFunc): Retrieves the string representation of a breakdown and its distribution
 //  for some cell of a table
-export function getBreakdownDistribWebStr({breakDown, getDistribution = true, includeTotal = true, formatValFunc = null}) {
+export function getBreakdownDistribWebStr({breakDown, getDistribution = true, includeTotal = true, formatValFunc = null, sort = -1, limit = 5}) {
   if (getDistribution) {
     breakDown = getBreakdownDistribution(breakDown);
   }
@@ -450,13 +494,9 @@ export function getBreakdownDistribWebStr({breakDown, getDistribution = true, in
   }
 
   const distribFormatFunc = (key, currentData) => `${formatValFunc(key, currentData.value)} (${currentData.distribution})`;
+  const getBreakdownVal = (dict, key) => dict[key].value;
+  const totalFormatValFunc = (key, val) => formatValFunc(key, val);
 
-  let result = DictTools.toWebStr(breakDown, distribFormatFunc);
-  if (!includeTotal) return result;
-
-  let totalValue = Object.values(breakDown).reduce((acc, currentVal) => acc + currentVal.value, 0);
-  totalValue = formatValFunc("total", totalValue);
-
-  const totalLine = Translation.translate("dataTable.breakDownTotal", {totalVal: totalValue, totalPercent: 100});
-  return `<b>${totalLine}</b><br>${result}`;
+  return getBreakdownWebStr({breakDown: breakDown, includeTotal: includeTotal, formatValFunc: distribFormatFunc, 
+                             sort: sort, limit: limit, getBreakdownVal: getBreakdownVal, totalFormatValFunc: totalFormatValFunc});
 }

--- a/src/graph/rbasg.js
+++ b/src/graph/rbasg.js
@@ -292,8 +292,8 @@ export function formatRbsagToDataTable(rbasgData, filters) {
   for (const row of dataTableData) {
     if (!isTotalRadionuclide) {
       row[DataTableHeader.EXPOSURE] = formatNumber(row[DataTableHeader.EXPOSURE][filters.chemical], filters);
-      row[DataTableHeader.PERCENT_NOT_TESTED] = DictTools.toWebStr(row[DataTableHeader.PERCENT_NOT_TESTED]);
-      row[DataTableHeader.PERCENT_UNDER_LOD] = DictTools.toWebStr(row[DataTableHeader.PERCENT_UNDER_LOD]);
+      row[DataTableHeader.PERCENT_NOT_TESTED] = DictTools.toWebStr(row[DataTableHeader.PERCENT_NOT_TESTED], (key, val) => formatPercent(val));
+      row[DataTableHeader.PERCENT_UNDER_LOD] = DictTools.toWebStr(row[DataTableHeader.PERCENT_UNDER_LOD], (key, val) => formatPercent(val));
     } else {
       row[DataTableHeader.EXPOSURE] = getBreakdownDistribWebStr({breakDown: row[DataTableHeader.EXPOSURE], formatValFunc: (key, val) => Translation.translateScientificNum(val)});
       row[DataTableHeader.PERCENT_NOT_TESTED] = getBreakdownWebStr({breakDown: row[DataTableHeader.PERCENT_NOT_TESTED], formatValFunc: (key, val) => formatPercent(val)});

--- a/src/graph/rbfg.js
+++ b/src/graph/rbfg.js
@@ -310,9 +310,9 @@ export function formatRbfgToDataTable(rbfgData, filters) {
   for (const row of result) {
     if (!isTotalRadionuclide) {
       row[DataTableHeader.EXPOSURE] = formatNumber(row[DataTableHeader.EXPOSURE][filters.chemical], filters);
-      row[DataTableHeader.PERCENT_EXPOSURE] = DictTools.toWebStr(row[DataTableHeader.PERCENT_EXPOSURE]);
-      row[DataTableHeader.PERCENT_NOT_TESTED] = DictTools.toWebStr(row[DataTableHeader.PERCENT_NOT_TESTED]);
-      row[DataTableHeader.PERCENT_UNDER_LOD] = DictTools.toWebStr(row[DataTableHeader.PERCENT_UNDER_LOD]);
+      row[DataTableHeader.PERCENT_EXPOSURE] = DictTools.toWebStr(row[DataTableHeader.PERCENT_EXPOSURE], (key, val) => formatPercent(val));
+      row[DataTableHeader.PERCENT_NOT_TESTED] = DictTools.toWebStr(row[DataTableHeader.PERCENT_NOT_TESTED], (key, val) => formatPercent(val));
+      row[DataTableHeader.PERCENT_UNDER_LOD] = DictTools.toWebStr(row[DataTableHeader.PERCENT_UNDER_LOD], (key, val) => formatPercent(val));
 
     } else {
       row[DataTableHeader.EXPOSURE] = getBreakdownDistribWebStr({breakDown: row[DataTableHeader.EXPOSURE], formatValFunc: (key, val) => Translation.translateScientificNum(val)});

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -97,10 +97,45 @@ export class DictTools {
   static toWebStr(dict, formatValFunc = null) {
     const dictKeys = Object.keys(dict);
     const dictLen = dictKeys.length;
+
+    if (formatValFunc == null) {
+      formatValFunc = (key, val) => val;
+    }
     
     if (dictLen == 0) return "";
     else if (dictLen > 1) return DictTools.toStr({dict: dict, end: "<br>", formatValFunc: formatValFunc});
-    return dict[dictKeys[0]];
+
+    const key = dictKeys[0];
+    return `${formatValFunc(key, dict[key])}`;
+  }
+
+  // mapToStr(map, end, formatValFunc): Converts a map to a string
+  static mapToStr({map, end = "\n", formatValFunc = null}) {
+    let result = [];
+    if (formatValFunc == null) {
+      formatValFunc = (key, val) => val;
+    }
+
+    for (const [key, val] of map) {
+      result.push(`${key}: ${formatValFunc(key, val)}`);
+    }
+
+    return result.join(end);
+  }
+
+  // mapToWebStr(map, formatValFunc): Converts a map to a string to be displayed on a webpage
+  static mapToWebStr(map, formatValFunc = null) {
+    const mapLen = map.size;
+
+    if (formatValFunc == null) {
+      formatValFunc = (key, val) => val;
+    }
+
+    if (mapLen == 0) return "";
+    else if (mapLen > 1) return DictTools.mapToStr({map: map, end: "<br>", formatValFunc: formatValFunc});
+
+    const [key, val] = map.entries().next().value;
+    return `${formatValFunc(key, val)}`;
   }
 
   // merge(dicts, keys): Merges multiple dictionaries toghether


### PR DESCRIPTION
- The breakdown in the table for total radionuclides is only limited to the top 5 contributors.
- Fixed the percentage formatting in the table

<br>

> [!NOTE]
> The values from the top 5 contributors do not necessarily add up to the total value since the the total includes all contributors