### PR TITLE
Remove HTML tags from Exposure Estimate Download

### DIFF
--- a/src/data/dataTranslator.js
+++ b/src/data/dataTranslator.js
@@ -430,7 +430,7 @@ export function getBreakdownDistribution(breakDown) {
 // getBreakdownWebStr(breakdown, includeTotal): Retrieves the string representation of some breakdown in some cell of a table
 export function getBreakdownWebStr({breakDown, includeTotal = true, formatValFunc = null, totalFormatValFunc = null,
                                     sort = -1, limit = 5, filter = null, getBreakdownVal = null, getTotalVal = null,
-                                    totalFormatPercentFunc = null}) {
+                                    totalFormatPercentFunc = null, forDownload = false}) {
   if (formatValFunc == null) {
     formatValFunc = (key, val) => val;
   }
@@ -488,7 +488,9 @@ export function getBreakdownWebStr({breakDown, includeTotal = true, formatValFun
     count += 1;
   }
 
-  let result = DictTools.mapToWebStr(newBreakdown, formatValFunc);
+  const newLineChar = (forDownload) ? "\n" : "<br>"
+
+  let result = DictTools.mapToWebStr({map: newBreakdown, formatValFunc: formatValFunc, end: newLineChar});
   if (!includeTotal) return result;
 
   let totalValue = 0;
@@ -502,13 +504,19 @@ export function getBreakdownWebStr({breakDown, includeTotal = true, formatValFun
 
   totalValue = totalFormatValFunc("total", totalValue);
   const totalLine = (newBreakdown.size > 0) ?  Translation.translate("dataTable.breakDownTotal", {totalVal: totalValue, totalPercent: totalFormatPercentFunc(100)}) : `${totalValue}`;
-  return `<b>${totalLine}</b><br>${result}`;
+
+  if (!forDownload) {
+    return `<b>${totalLine}</b><br>${result}`;
+  }
+
+  return `${totalLine}\n${result}`;
 }
 
 // getBreakdownDistribWebStr(breakDown, getDistribution, includeTotal, formatValFunc): Retrieves the string representation of a breakdown and its distribution
 //  for some cell of a table
 export function getBreakdownDistribWebStr({breakDown, getDistribution = true, includeTotal = true, formatValFunc = null, sort = -1, limit = 5, 
-                                           filter = null, getTotalVal = null, totalFormatValFunc = null, totalFormatPercentFunc = null}) {
+                                           filter = null, getTotalVal = null, totalFormatValFunc = null, totalFormatPercentFunc = null,
+                                           forDownload = false}) {
   if (getDistribution) {
     breakDown = getBreakdownDistribution(breakDown);
   }
@@ -526,5 +534,5 @@ export function getBreakdownDistribWebStr({breakDown, getDistribution = true, in
 
   return getBreakdownWebStr({breakDown: breakDown, includeTotal: includeTotal, formatValFunc: distribFormatFunc, 
                              sort: sort, limit: limit, filter: filter, getBreakdownVal: getBreakdownVal, totalFormatValFunc: totalFormatValFunc, 
-                             getTotalVal: getTotalVal, totalFormatValFunc: totalFormatValFunc, totalFormatPercentFunc: totalFormatPercentFunc});
+                             getTotalVal: getTotalVal, totalFormatValFunc: totalFormatValFunc, totalFormatPercentFunc: totalFormatPercentFunc, forDownload: forDownload});
 }

--- a/src/graph/rbasg.js
+++ b/src/graph/rbasg.js
@@ -247,7 +247,7 @@ export function getRbasg(tdsData, filters) {
  * Returns:
  * - An array of objects adhering to the contract specified in the displayDataTable function of dataTableComponent.js
  */
-export function formatRbsagToDataTable(rbasgData, filters) {
+export function formatRbsagToDataTable(rbasgData, filters, forDownload = false) {
   let dataTableData = {};
   const chemIsTotal = isTotalChemical(filters.chemical);
 
@@ -324,20 +324,20 @@ export function formatRbsagToDataTable(rbasgData, filters) {
                                                                  formatValFunc: (key, val) => Translation.translateScientificNum(val),
                                                                  totalFormatPercentFunc: (val) => Translation.translate("total"),
                                                                  filter: (key, val) => val.value != 0,
-                                                                 sort: exposureChemicals});
+                                                                 sort: exposureChemicals, forDownload: forDownload});
 
       row[DataTableHeader.PERCENT_NOT_TESTED] = getBreakdownWebStr({breakDown: row[DataTableHeader.PERCENT_NOT_TESTED], 
                                                                     formatValFunc: (key, val) => formatPercent(val), 
                                                                     getTotalVal: (breakDown) => (totalComposites.size - totalCompositesTested.size) / totalComposites.size * 100,
                                                                     totalFormatPercentFunc: (val) => Translation.translate("total"),
                                                                     filter: (key, val) => val != 0,
-                                                                    sort: exposureChemicals});
+                                                                    sort: exposureChemicals, forDownload: forDownload});
 
       row[DataTableHeader.PERCENT_UNDER_LOD] = getBreakdownWebStr({breakDown: row[DataTableHeader.PERCENT_UNDER_LOD], 
                                                                    formatValFunc: (key, val) => formatPercent(val),
                                                                    totalFormatPercentFunc: (val) => Translation.translate("total"),
                                                                    filter: (key, val) => val != 0,
-                                                                   sort: exposureChemicals});
+                                                                   sort: exposureChemicals, forDownload: forDownload});
     }
 
     row[DataTableHeader.EXPOSURE_UNIT] = DictTools.toWebStr(row[DataTableHeader.EXPOSURE_UNIT], null, true);

--- a/src/graph/rbf.js
+++ b/src/graph/rbf.js
@@ -133,7 +133,7 @@ export function getRbf(tdsData, filters) {
  * Returns:
  * - An array of objects adhering to the contract specified in the displayDataTable function of dataTableComponent.js
  */
-export function formatRbfToDataTable(rbfData, filters) {
+export function formatRbfToDataTable(rbfData, filters, forDownload = false) {
   const dataTableData = Object.values(rbfData).map((row) => {
     const compositeInfo = getCompositeInfo(row);
 

--- a/src/graph/rbfg.js
+++ b/src/graph/rbfg.js
@@ -254,7 +254,7 @@ export function getRbfg(tdsData, filters) {
  * Returns:
  * - An array of objects adhering to the contract specified in the displayDataTable function of dataTableComponent.js
  */
-export function formatRbfgToDataTable(rbfgData, filters) {
+export function formatRbfgToDataTable(rbfgData, filters, forDownload = false) {
   const dataTableData = {};
   const chemIsTotal = isTotalChemical(filters.chemical);
 
@@ -349,26 +349,26 @@ export function formatRbfgToDataTable(rbfgData, filters) {
                                                                  formatValFunc: (key, val) => Translation.translateScientificNum(val),
                                                                  totalFormatPercentFunc: (val) => Translation.translate("total"),
                                                                  filter: (key, val) => val.value != 0,
-                                                                 sort: exposureChemicals});
+                                                                 sort: exposureChemicals, forDownload: forDownload});
 
       row[DataTableHeader.PERCENT_EXPOSURE] = getBreakdownWebStr({breakDown: row[DataTableHeader.PERCENT_EXPOSURE], 
                                                                   formatValFunc: (key, val) => formatPercent(val),
                                                                   totalFormatPercentFunc: (val) => Translation.translate("total"),
                                                                   filter: (key, val) => val != 0,
-                                                                  sort: exposureChemicals});
+                                                                  sort: exposureChemicals, forDownload: forDownload});
 
       row[DataTableHeader.PERCENT_NOT_TESTED] = getBreakdownWebStr({breakDown: row[DataTableHeader.PERCENT_NOT_TESTED], 
                                                                     formatValFunc: (key, val) => formatPercent(val), 
                                                                     getTotalVal: (breakDown) => (totalComposites[row.foodGroup].size - totalCompositesTested[row.foodGroup].size) / totalComposites[row.foodGroup].size * 100,
                                                                     totalFormatPercentFunc: (val) => Translation.translate("total"),
                                                                     filter: (key, val) => val != 0,
-                                                                    sort: exposureChemicals});
+                                                                    sort: exposureChemicals, forDownload: forDownload});
 
       row[DataTableHeader.PERCENT_UNDER_LOD] = getBreakdownWebStr({breakDown: row[DataTableHeader.PERCENT_UNDER_LOD], 
                                                                    formatValFunc: (key, val) => formatPercent(val),
                                                                    totalFormatPercentFunc: (val) => Translation.translate("total"),
                                                                    filter: (key, val) => val != 0,
-                                                                   sort: exposureChemicals});
+                                                                   sort: exposureChemicals, forDownload: forDownload});
     }
 
     row[DataTableHeader.EXPOSURE_UNIT] = DictTools.toWebStr(row[DataTableHeader.EXPOSURE_UNIT], null, true);

--- a/src/ui/dataTableComponent.js
+++ b/src/ui/dataTableComponent.js
@@ -106,7 +106,7 @@ export function downloadDataTable(tdsData, graphType) {
   const specificData = getDataFn(tdsData, filters);
   const data = {
     filename: getTranslations().dataTable.exportNames.calculations,
-    rows: getDataTableDataFn(specificData, filters),
+    rows: getDataTableDataFn(specificData, filters, true),
     csvFilename: ""
   };
 

--- a/src/util/data.js
+++ b/src/util/data.js
@@ -103,7 +103,7 @@ export class DictTools {
     return result.join(end);
   }
 
-  static _toWebStr(dict, formatValFunc = null) {
+  static _toWebStr(dict, formatValFunc = null, end = "<br>") {
     const dictKeys = Object.keys(dict);
     const dictLen = dictKeys.length;
 
@@ -112,7 +112,7 @@ export class DictTools {
     }
     
     if (dictLen == 0) return "";
-    else if (dictLen > 1) return DictTools.toStr({dict: dict, end: "<br>", formatValFunc: formatValFunc});
+    else if (dictLen > 1) return DictTools.toStr({dict: dict, end: end, formatValFunc: formatValFunc});
 
     const key = dictKeys[0];
     return `${formatValFunc(key, dict[key])}`;
@@ -159,7 +159,7 @@ export class DictTools {
   }
 
   // mapToWebStr(map, formatValFunc): Converts a map to a string to be displayed on a webpage
-  static mapToWebStr(map, formatValFunc = null) {
+  static mapToWebStr({map, formatValFunc = null, end = "<br>"}) {
     const mapLen = map.size;
 
     if (formatValFunc == null) {
@@ -167,7 +167,7 @@ export class DictTools {
     }
 
     if (mapLen == 0) return "";
-    else if (mapLen > 1) return DictTools.mapToStr({map: map, end: "<br>", formatValFunc: formatValFunc});
+    else if (mapLen > 1) return DictTools.mapToStr({map: map, end: end, formatValFunc: formatValFunc});
 
     const [key, val] = map.entries().next().value;
     return `${key}: ${formatValFunc(key, val)}`;


### PR DESCRIPTION
- The data for the exposure estimate uses the same data from the tables on the website. But for distribution breakdowns, certain columns added the `<br>` or `<b>` tags. We do not want these extra tags