### PR TITLE
Fix 0 exposure value in tool tip of stack bar graph

### DIFF
--- a/src/graph/rbfg.js
+++ b/src/graph/rbfg.js
@@ -459,7 +459,7 @@ export function formatRbfgToStackedBar(rbfgData, filters, colorMapping) {
         }
 
         graphDataEntry.value += exposure;
-        graphDataEntry.info = getRbfgGraphInfo(filters, exposure, ageSexGroup, foodGroup, contaminantUnit);
+        graphDataEntry.info = getRbfgGraphInfo(filters, graphDataEntry.value, ageSexGroup, foodGroup, contaminantUnit);
       });
     });
   }


### PR DESCRIPTION
For the `total...` chemicals, the exposure value is supposed to be the sum of all the exposure values for all the chemicals, not just the exposure value of the last chemical