### PR TITLE
Update the reset modified values button

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,6 +302,10 @@
         <div class="filter hidden">
           <button class="btn btn-danger filter-button" id="filter-reset-button"></button>
         </div>
+
+        <div class="filter hidden">
+          <button type="button" class="btn btn-danger filter-button" id="sandbox-reset-button" disabled></button>
+        </div>
       </div>
   
       <!--
@@ -391,7 +395,6 @@
 
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-danger" id="sandbox-reset-button"></button>
             </div>
           </div>
         </div>

--- a/src/const.js
+++ b/src/const.js
@@ -868,7 +868,7 @@ const LangEN = {
     sandbox: {
       openButton: "Modify Graph/Values",
       closeButton: "Close",
-      resetButton: "Reset",
+      resetButton: "Reset Modify Values",
       title: "Modify Graph/Values",
       subtitle:
         "Any new values that are added will apply to all three graphs.",
@@ -1567,7 +1567,7 @@ const LangFR = {
     sandbox: {
       openButton: "Modifier le graphique/les valeurs",
       closeButton: "Fermer",
-      resetButton: "Réinitialiser",
+      resetButton: "Réinitialiser Valeurs Modifiées",
       title: "Modifier le graphique/les valeurs",
       subtitle:
         "Toute nouvelle valeur ajoutée s'appliquera aux trois graphiques.",

--- a/src/ui/filter.js
+++ b/src/ui/filter.js
@@ -355,6 +355,13 @@ export function rbfgLegendOnClick(foodGroup) {
   displayGraph(getFilteredTdsData());
 }
 
+// isSandboxReset(): Determines whether the sandbox has reset to its default state
+function isSandboxReset() {
+  return !el.filters.sandbox.overridesList.hasChildNodes() && 
+          el.filters.inputs.referenceLine.value == "" &&
+          el.filters.sandbox.showSuppressedButton.innerHTML == Translation.translate("filters.sandbox.showSuppressed"); 
+}
+
 /**
  * Initialize all the event listeners related to the filters.
  */
@@ -368,6 +375,7 @@ function addEventListenersToFilters() {
     clearError(el.filters.inputs.referenceLine);
     clearError(el.filters.inputs.overrideValue);
     displayGraph(getFilteredTdsData());
+    el.filters.sandbox.resetButton.disabled = true;
   });
 
   el.filters.inputs.chemicalGroup.addEventListener("change", () => {
@@ -407,11 +415,11 @@ function addEventListenersToFilters() {
 
   el.filters.inputs.referenceLine.addEventListener('input', (event) => {
     const errorMsgs = displayError(el.filters.inputs.referenceLine, "ReferenceLine"); 
+    if (errorMsgs.length > 0 || !selectionsCompleted()) return;
 
-    if (errorMsgs.length == 0 && selectionsCompleted()) {
-      showFilters();
-      displayGraph(getFilteredTdsData());
-    }
+    el.filters.sandbox.resetButton.disabled = false;
+    showFilters();
+    displayGraph(getFilteredTdsData());
   });
 
   el.filters.inputs.overrideValue.addEventListener("input", (event) => {
@@ -441,12 +449,18 @@ function addEventListenersToFilters() {
       removeButton.classList.add(classes.SANDBOX_BUTTON);
       removeButton.innerHTML =
         getTranslations().filters.sandbox.removeOverrideButton;
+
       removeButton.addEventListener("click", () => {
         el.filters.sandbox.overridesList.removeChild(itemContainer);
         Array.from(el.filters.inputs.overrideFood.options).find(
           (option) =>
             JSON.parse(option.value || null)?.composite == override.composite,
         ).disabled = false;
+
+        if (isSandboxReset()) {
+          el.filters.sandbox.resetButton.disabled = true;
+        }
+
         displayGraph(getFilteredTdsData());
       });
 
@@ -454,6 +468,7 @@ function addEventListenersToFilters() {
       itemContainer.appendChild(removeButton);
       el.filters.sandbox.overridesList.appendChild(itemContainer);
       el.filters.inputs.overrideValue.value = null;
+      el.filters.sandbox.resetButton.disabled = false;
     }
 
     displayGraph(getFilteredTdsData());
@@ -470,11 +485,16 @@ function addEventListenersToFilters() {
       ) {
         el.filters.sandbox.showSuppressedButton.innerHTML =
           getTranslations().filters.sandbox.dontShowSuppressed;
+        el.filters.sandbox.resetButton.disabled = false;
+
         displayGraph(getFilteredTdsData());
       }
     } else {
-      el.filters.sandbox.showSuppressedButton.innerHTML =
-        getTranslations().filters.sandbox.showSuppressed;
+      el.filters.sandbox.showSuppressedButton.innerHTML = getTranslations().filters.sandbox.showSuppressed;
+      if (isSandboxReset()) {
+        el.filters.sandbox.resetButton.disabled = true;
+      }
+
       displayGraph(getFilteredTdsData());
     }
   });
@@ -1016,6 +1036,7 @@ export function updateSandbox(filteredTdsData, filters) {
  */
 export function clearSandbox() {
   el.filters.inputs.referenceLine.value = "";
+  el.filters.sandbox.showSuppressedButton.innerHTML = Translation.translate("filters.sandbox.showSuppressed"); 
   displayOverrideFoodFilter();
 }
 

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,7 @@
   --surface: #ffffff;
   --secondarySurface: #fbfcf8;
   --error: #ff0000;
+  --errorDisabled: #f28585;
   --onBackground: #000000;
   --onSurface: #000000;
   --onSecondarySurface: #000000;
@@ -546,7 +547,7 @@ Legend
   --bs-btn-active-bg: var(--primaryHover);
   --bs-btn-active-border-color: var(--primaryBorderColour);
   --bs-btn-disabled-color: var(--onPrimary);
-  --bs-btn-disabled-bg: var(--error);
+  --bs-btn-disabled-bg: var(--errorDisabled);
   --bs-btn-disabled-border-color: var(--primaryBorderColour);
   transition: var(--defaultTransition);
 }


### PR DESCRIPTION
- Change the position of the modified values button to be next to the reset button in the main page
- Disable the button reset modified values button when the modified values modal is at the default state, otherwise the button is enabled
- Fix the `Include/Exclude Consumption Values with CV > 33.3%` not resetting when the user prsses the reset modified values button