### PR TITLE
Add a unit prefix dropdown for the graphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,6 +258,14 @@
           ></label>
           <select id="filter-rbfg-sex-select" multiple data-actions-box="true" data-live-search="true"></select>
         </div>
+
+        <div class="filter hidden">
+          <label
+            id="filter-consumption-sub-units-title"
+            for="filter-consumption-sub-units-select"
+          ></label>
+          <select class="form-select" id="filter-consumption-sub-units-select"></select>
+        </div>
   
         <div id="filter-consumption-units-container" class="filter hidden">
           <label

--- a/src/const.js
+++ b/src/const.js
@@ -122,6 +122,13 @@ export const ConsumptionUnits = {
   KGBW: "KGBW",
 };
 
+export const ConsumptionSubUnits = {
+  MICRO: "u",
+  PICO: "p",
+  NANO: "n",
+  MILLI: "m"
+};
+
 export const RbasgDomainFormat = {
   AGESEX: "AGESEX",
   YEAR: "YEAR",
@@ -826,7 +833,8 @@ const LangEN = {
       multiSelAllSubtitle: "Select all with Ctrl-a",
       lod: "Treatment of Values &ltLOD",
       lodSubtitle: "LOD Range: ",
-      units: "Units",
+      units: "Basis",
+      subUnits: "Unit",
       ageGroup: "Age Groups",
       age: "Age",
       sex: "Sex",
@@ -850,8 +858,14 @@ const LangEN = {
       [LODs.Exclude]: "Exclude",
     },
     consumptionUnits: {
-      [ConsumptionUnits.PERSON]: "ng/day",
-      [ConsumptionUnits.KGBW]: "ng/kg bw per day",
+      [ConsumptionUnits.PERSON]: "day",
+      [ConsumptionUnits.KGBW]: "kg bw per day",
+    },
+    consumptionSubUnits: {
+      [ConsumptionSubUnits.MILLI]: "mg",
+      [ConsumptionSubUnits.MICRO]: "μg",
+      [ConsumptionSubUnits.NANO]: "ng",
+      [ConsumptionSubUnits.PICO]: "pg",
     },
     rbasgDomainFormat: {
       [RbasgDomainFormat.AGESEX]: "Age Group",
@@ -1525,7 +1539,8 @@ const LangFR = {
       multiSelAllSubtitle: "Tout sélectionner avec Ctrl-a",
       lod: "Traitement des valeurs <LD",
       lodSubtitle: "Fourchette LD: ",
-      units: "Unités",
+      units: "Base",
+      subUnits: "Unités",
       ageGroup: "Groupes d'âge",
       age: "Âge",
       sex: "Sexe",
@@ -1549,8 +1564,14 @@ const LangFR = {
       [LODs.Exclude]: "Exclure",
     },
     consumptionUnits: {
-      [ConsumptionUnits.PERSON]: "ng/jour",
-      [ConsumptionUnits.KGBW]: "ng/kg pc par jour",
+      [ConsumptionUnits.PERSON]: "jour",
+      [ConsumptionUnits.KGBW]: "kg pc par jour",
+    },
+    consumptionSubUnits: {
+      [ConsumptionSubUnits.MILLI]: "mg",
+      [ConsumptionSubUnits.MICRO]: "μg",
+      [ConsumptionSubUnits.NANO]: "ng",
+      [ConsumptionSubUnits.PICO]: "pg",
     },
     rbasgDomainFormat: {
       [RbasgDomainFormat.AGESEX]: "Groupe d'âge",

--- a/src/data/dataTranslator.js
+++ b/src/data/dataTranslator.js
@@ -8,7 +8,8 @@ import {
   getConsumptionFiles,
   PFASGroupings,
   getTranslations,
-  Translation
+  Translation,
+  ConsumptionSubUnits
 } from "../const.js";
 import { readCSV } from "./dataLoader.js";
 import { formatDownloadName } from "./dataDownloader.js";
@@ -535,4 +536,17 @@ export function getBreakdownDistribWebStr({breakDown, getDistribution = true, in
   return getBreakdownWebStr({breakDown: breakDown, includeTotal: includeTotal, formatValFunc: distribFormatFunc, 
                              sort: sort, limit: limit, filter: filter, getBreakdownVal: getBreakdownVal, totalFormatValFunc: totalFormatValFunc, 
                              getTotalVal: getTotalVal, totalFormatValFunc: totalFormatValFunc, totalFormatPercentFunc: totalFormatPercentFunc, forDownload: forDownload});
+}
+
+// convertConsumptionUnits(consumption, unit): Converts the consumption based on the required unit prefix
+export function convertConsumptionUnits(consumption, unit) {
+  if (unit == ConsumptionSubUnits.MICRO) {
+    consumption /= 1000;
+  } else if (unit ==  ConsumptionSubUnits.PICO) {
+    consumption *= 1000;
+  } else if (unit == ConsumptionSubUnits.MILLI) {
+    consumption /= 1000000;
+  }
+
+  return consumption;
 }

--- a/src/graph/rbasg.js
+++ b/src/graph/rbasg.js
@@ -24,7 +24,7 @@ import {
   TableTools,
   isTotalChemical
 } from "../util/data.js";
-import { getBreakdownDistribWebStr, getBreakdownWebStr, groupContaminantsByChecmical } from "../data/dataTranslator.js";
+import { convertConsumptionUnits, getBreakdownDistribWebStr, getBreakdownWebStr, groupContaminantsByChecmical } from "../data/dataTranslator.js";
 
 
 // getChemicalRbasg(tdsData, filters): Retrieves the data for results by age-sex group
@@ -279,8 +279,8 @@ export function formatRbsagToDataTable(rbasgData, filters, forDownload = false) 
           dataTableData[row.ageSexGroup] = {
             [DataTableHeader.CHEMICAL]: filters.chemical,
             [DataTableHeader.AGE_SEX_GROUP]: getAgeSexDisplay(row.ageSexGroup),
-            [DataTableHeader.EXPOSURE]: {[chemical]: row.exposure},
-            [DataTableHeader.EXPOSURE_UNIT]: {[chemical]: getExposureUnit(row.contaminantUnit, filters)},
+            [DataTableHeader.EXPOSURE]: {[chemical]: convertConsumptionUnits(row.exposure, filters.unitPrefix)},
+            [DataTableHeader.EXPOSURE_UNIT]: {[chemical]: getExposureUnit(filters.unitPrefixVal, filters)},
             [DataTableHeader.YEARS]: currentYears,
             [DataTableHeader.PERCENT_NOT_TESTED]: {[chemical]: row.percentNotTested},
             [DataTableHeader.PERCENT_UNDER_LOD]: {[chemical]: row.percentUnderLod},
@@ -300,8 +300,8 @@ export function formatRbsagToDataTable(rbasgData, filters, forDownload = false) 
           return;
         }
 
-        dataTableRow[DataTableHeader.EXPOSURE][chemical] = row.exposure;
-        dataTableRow[DataTableHeader.EXPOSURE_UNIT][chemical] = getExposureUnit(row.contaminantUnit, filters);
+        dataTableRow[DataTableHeader.EXPOSURE][chemical] = convertConsumptionUnits(row.exposure, filters.unitPrefix);
+        dataTableRow[DataTableHeader.EXPOSURE_UNIT][chemical] = getExposureUnit(filters.unitPrefixVal, filters);
         SetTools.union(dataTableRow[DataTableHeader.YEARS], currentYears, false);
         dataTableRow[DataTableHeader.PERCENT_NOT_TESTED][chemical] = row.percentNotTested;
         dataTableRow[DataTableHeader.PERCENT_UNDER_LOD][chemical] = row.percentUnderLod;
@@ -370,7 +370,7 @@ export function formatRbsagToDataTable(rbasgData, filters, forDownload = false) 
 
 function getRbasgGraphInfo(filters, exposure, entry, sexDisplay, exposureUnit) {
   return  Translation.translate("graphs.info.exposure") + ": " +
-          formatNumber(exposure, filters) + " " +
+          formatNumber(convertConsumptionUnits(exposure, filters.unitPrefix), filters) + " " +
           exposureUnit + "\n" +
           Translation.translate(filters.showByAgeSexGroup ? "graphs.info.ageSexGroup" : "graphs.info.year") + ": " +
           (filters.showByAgeSexGroup ? entry + " " + sexDisplay : entry);
@@ -390,7 +390,7 @@ export function formatRbasgToGroupedBar(rbasgData, filters, colorMapping) {
   }
 
   const contaminantUnit = Object.values(Object.values(Object.values(rbasgData)[0])[0])[0].contaminantUnit;
-  const exposureUnit = getExposureUnit(contaminantUnit, filters);
+  const exposureUnit = getExposureUnit(filters.unitPrefixVal, filters);
 
   const groupedBarData = {
     children: [],
@@ -422,14 +422,14 @@ export function formatRbasgToGroupedBar(rbasgData, filters, colorMapping) {
           graphData[graphDataId] = {
             entry: entry,
             group: sexDisplay,
-            value: row.exposure,
+            value: convertConsumptionUnits(row.exposure, filters.unitPrefix),
             color: colorMapping[sex].color,
             info: getRbasgGraphInfo(filters, row.exposure, entry, sexDisplay, exposureUnit)
           }
           return;
         }
 
-        graphDataEntry.value += row.exposure;
+        graphDataEntry.value += convertConsumptionUnits(row.exposure, filters.unitPrefix);
         graphDataEntry.info = getRbasgGraphInfo(filters, graphDataEntry.value, entry, sexDisplay, exposureUnit);
       });
     });

--- a/src/graph/rbf.js
+++ b/src/graph/rbf.js
@@ -12,6 +12,7 @@ import {
   getExposureUnit,
   getUserModifiedValueText,
 } from "../util/data.js";
+import { convertConsumptionUnits } from "../data/dataTranslator.js";
 
 /**
  * Take in TDS data and return data which has been strictly filtered and formatted
@@ -144,11 +145,8 @@ export function formatRbfToDataTable(rbfData, filters, forDownload = false) {
       [DataTableHeader.COMPOSITE_NAME]: row.compositeDesc,
       [DataTableHeader.COMPOSITE_CODE]: row.composite,
       [DataTableHeader.PERCENT_EXPOSURE]: formatPercent(row.percentExposure),
-      [DataTableHeader.EXPOSURE]: formatNumber(row.exposure, filters),
-      [DataTableHeader.EXPOSURE_UNIT]: getExposureUnit(
-        row.contaminantUnit,
-        filters,
-      ),
+      [DataTableHeader.EXPOSURE]: formatNumber(convertConsumptionUnits(row.exposure, filters.unitPrefix), filters),
+      [DataTableHeader.EXPOSURE_UNIT]: getExposureUnit(filters.unitPrefixVal, filters),
       [DataTableHeader.YEARS]: filters.years.join(", "),
       [DataTableHeader.PERCENT_UNDER_LOD]: formatPercent(row.percentUnderLod),
       [DataTableHeader.TREATMENT]: filters.lod,
@@ -201,9 +199,9 @@ export function formatRbfToSunburst(rbfData, filters, colorMapping) {
         ")\n" +
         getTranslations().graphs.info.exposure +
         ": " +
-        formatNumber(row.exposure, filters) +
+        formatNumber(convertConsumptionUnits(row.exposure, filters.unitPrefix), filters) +
         " " +
-        getExposureUnit(row.contaminantUnit, filters) +
+        getExposureUnit(filters.unitPrefixVal, filters) +
         "\n" +
         getTranslations().graphs.info.percentExposure +
         ": " +

--- a/src/graph/rbfg.js
+++ b/src/graph/rbfg.js
@@ -25,7 +25,7 @@ import {
   getContaminantExposure,
   getOccurrenceForContaminantEntry,
 } from "../util/graph.js";
-import { getBreakdownDistribWebStr, getBreakdownWebStr, groupContaminantsByChecmical } from "../data/dataTranslator.js";
+import { getBreakdownDistribWebStr, getBreakdownWebStr, groupContaminantsByChecmical, convertConsumptionUnits } from "../data/dataTranslator.js";
 
 
 // getChemicalRbfg(tdsData, filters): Retrieves the data for results by age-sex group
@@ -295,8 +295,8 @@ export function formatRbfgToDataTable(rbfgData, filters, forDownload = false) {
             [DataTableHeader.AGE_SEX_GROUP]: getAgeSexDisplay(row.ageSexGroup),
             [DataTableHeader.FOOD_GROUP]: row.foodGroup,
             [DataTableHeader.PERCENT_EXPOSURE]: {[chemical]: row.percentExposure},
-            [DataTableHeader.EXPOSURE]: {[chemical]: row.exposure},
-            [DataTableHeader.EXPOSURE_UNIT]: {[chemical]: getExposureUnit(row.contaminantUnit, filters)},
+            [DataTableHeader.EXPOSURE]: {[chemical]: convertConsumptionUnits(row.exposure, filters.unitPrefix)},
+            [DataTableHeader.EXPOSURE_UNIT]: {[chemical]: getExposureUnit(filters.unitPrefixVal, filters)},
             [DataTableHeader.YEARS]: currentYears,
             [DataTableHeader.PERCENT_NOT_TESTED]: {[chemical]: row.percentNotTested},
             [DataTableHeader.PERCENT_UNDER_LOD]: {[chemical]: row.percentUnderLod},
@@ -305,7 +305,7 @@ export function formatRbfgToDataTable(rbfgData, filters, forDownload = false) {
             [DataTableHeader.FLAGGED]: new Set(row.consumptionsFlagged),
             [DataTableHeader.SUPPRESSED]: new Set(row.consumptionsSuppressed),
             [DataTableHeader.INCLUDED_SUPPRESSED]: new Set(filters.useSuppressedHighCvValues ? row.consumptionsSuppressedWithHighCv : []),
-            foodGroup: row.foodGroup
+            [DataTableHeader.FOOD_GROUP]: row.foodGroup
           };
 
           dataTableRow = foodGroupRow[row.ageSexGroup];
@@ -317,10 +317,10 @@ export function formatRbfgToDataTable(rbfgData, filters, forDownload = false) {
           return;
         }
 
-        dataTableRow.foodGroup = row.foodGroup;
+        dataTableRow[DataTableHeader.FOOD_GROUP] = row[DataTableHeader.FOOD_GROUP];
         dataTableRow[DataTableHeader.PERCENT_EXPOSURE][chemical] = row.percentExposure;
-        dataTableRow[DataTableHeader.EXPOSURE][chemical] = row.exposure;
-        dataTableRow[DataTableHeader.EXPOSURE_UNIT][chemical] = getExposureUnit(row.contaminantUnit, filters);
+        dataTableRow[DataTableHeader.EXPOSURE][chemical] = convertConsumptionUnits(row.exposure, filters.unitPrefix);
+        dataTableRow[DataTableHeader.EXPOSURE_UNIT][chemical] = getExposureUnit(filters.unitPrefixVal, filters);
         SetTools.union(dataTableRow[DataTableHeader.YEARS], currentYears, false);
         dataTableRow[DataTableHeader.PERCENT_NOT_TESTED][chemical] = row.percentNotTested;
         dataTableRow[DataTableHeader.PERCENT_UNDER_LOD][chemical] = row.percentUnderLod;
@@ -431,7 +431,7 @@ export function formatRbfgToStackedBar(rbfgData, filters, colorMapping) {
       getTranslations().graphs[GraphTypes.RBFG].range[
         filters.usePercent ? RbfgRangeFormat.PERCENT : RbfgRangeFormat.NUMBER
       ]
-    } (${getExposureUnit(contaminantUnit, filters)})`,
+    } (${getExposureUnit(filters.unitPrefixVal, filters)})`,
     titleX: getTranslations().graphs[GraphTypes.RBFG].domain,
   };
 

--- a/src/ui/const.js
+++ b/src/ui/const.js
@@ -96,9 +96,9 @@ export const el = {
       ),
       lod: document.getElementById("filter-lod-title"),
       lodSubtitle: document.getElementById("filter-lod-subtitle"),
-      consumptionUnits: document.getElementById(
-        "filter-consumption-units-title",
-      ),
+      consumptionUnits: document.getElementById("filter-consumption-units-title"),
+      consumptionSubUnits: document.getElementById("filter-consumption-sub-units-title"),
+
       rbasgAgeGroup: document.getElementById(
         "filter-rbasg-age-group-filter-title",
       ),
@@ -143,6 +143,7 @@ export const el = {
       consumptionUnits: document.getElementById(
         "filter-consumption-units-select",
       ),
+      consumptionSubUnits: document.getElementById("filter-consumption-sub-units-select"),
       referenceLine: document.getElementById("filter-reference-line-select"),
       overrideFood: document.getElementById("filter-override-food-select"),
       overrideValue: document.getElementById("filter-override-value-select"),

--- a/src/ui/filter.js
+++ b/src/ui/filter.js
@@ -1,5 +1,5 @@
 import { classes, el } from "./const.js";
-import { ageGroupOrder, getTranslations, sexGroupOrder, sexGroups, Translation } from "../const.js";
+import { ageGroupOrder, ConsumptionSubUnits, getTranslations, sexGroupOrder, sexGroups, Translation } from "../const.js";
 import { displayGraph } from "./graphComponent.js";
 import {
   ConsumptionUnits,
@@ -154,6 +154,9 @@ export function getActiveFilters() {
   ageGroups = Array.from(ageGroups);
   sexGroups = Array.from(sexGroups);
 
+  const selectedConsumptionSubUnitNode = d3.select(el.filters.inputs.consumptionSubUnits).select("option:checked");
+  const consumptionSubUnitText = (selectedConsumptionSubUnitNode.empty()) ? "" : selectedConsumptionSubUnitNode.text();
+
   return {
     chemicalGroup: el.filters.inputs.chemicalGroup.value,
     chemical: el.filters.inputs.chemical.value,
@@ -185,6 +188,8 @@ export function getActiveFilters() {
     usePerPersonPerDay:
       el.filters.inputs.consumptionUnits.value ==
       getTranslations().filters.consumptionUnits[ConsumptionUnits.PERSON],
+    unitPrefix: el.filters.inputs.consumptionSubUnits.value,
+    unitPrefixVal: consumptionSubUnitText,
     sortByFood:
       el.graphs[GraphTypes.RBF].filters.sortBy.value ==
       getTranslations().filters.rbfSortByFormat[RbfSortByFormat.FOOD],
@@ -397,6 +402,7 @@ function addEventListenersToFilters() {
     el.filters.inputs.chemical,
     el.filters.inputs.lod,
     el.filters.inputs.consumptionUnits,
+    el.filters.inputs.consumptionSubUnits,
     el.graphs[GraphTypes.RBASG].filters.domain,
     ...Object.values(el.graphs[GraphTypes.RBF].filters),
     el.graphs[GraphTypes.RBFG].filters.range,
@@ -511,7 +517,8 @@ export function displayFilterText() {
   displayChemicals();
   displayLods();
   displayNonChemFilters();
-  displayConsumptionUnits();
+  displayConsumptionBaseUnits();
+  displayConsumptionSubUnits();
   displayRbasgDomainFilter();
   displayRbfSortByFilter();
   displayRbfgRangeFilter();
@@ -714,7 +721,7 @@ function displayLods() {
   });
 }
 
-function displayConsumptionUnits() {
+function displayConsumptionBaseUnits() {
   el.filters.inputs.consumptionUnits.innerHTML = "";
   Object.keys(ConsumptionUnits).forEach((key) => {
     const unit = getTranslations().filters.consumptionUnits[key];
@@ -722,6 +729,17 @@ function displayConsumptionUnits() {
     oe.value = unit;
     oe.text = unit;
     el.filters.inputs.consumptionUnits.appendChild(oe);
+  });
+}
+
+function displayConsumptionSubUnits() {
+  el.filters.inputs.consumptionSubUnits.innerHTML = "";
+  Object.values(ConsumptionSubUnits).forEach((key) => {
+    const unit = getTranslations().filters.consumptionSubUnits[key];
+    const oe = document.createElement("option");
+    oe.value = key;
+    oe.text = unit;
+    el.filters.inputs.consumptionSubUnits.appendChild(oe);
   });
 }
 

--- a/src/ui/page.js
+++ b/src/ui/page.js
@@ -162,6 +162,7 @@ export async function initializePageText() {
     translations.filters.titles.lodSubtitle;
   el.filters.titles.consumptionUnits.innerHTML =
     translations.filters.titles.units;
+  el.filters.titles.consumptionSubUnits.innerHTML = Translation.translate("filters.titles.subUnits");
   el.filters.titles.rbasgAgeGroup.innerHTML =
     translations.filters.titles.ageGroup;
   el.filters.titles.rbasgSexGroup.innerHTML = Translation.translate("filters.titles.sex");


### PR DESCRIPTION
- Separated the original unit dropdown to 2 different dropdowns:
   - A new dropdown for the unit prefix for grams
   - The original dropdown for the base units in the denominator
- The change for adding the unit prefix dropdown (micro, pico, nano, milli, etc...) will affect:
   - The graphs and their tooltips
   - The tables
   - The downloaded table